### PR TITLE
feat: add more tags to sentry

### DIFF
--- a/src/Utils/ErrorHandler.php
+++ b/src/Utils/ErrorHandler.php
@@ -47,8 +47,15 @@ class ErrorHandler
                 'dsn' => $sentryDsn,
                 'environment' => Env::get('APP_ENV'),
                 'release' => Env::get('APP_NAME') . '@' . Env::get('APP_VERSION'),
-                'server_name' => $_SERVER['SERVER_NAME'] ?? 'n/a'
+                'server_name' => Env::get('APP_NAME')
             ]);
+            \Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
+                $scope->setUser([
+                    'id' => JwtAuthentication::tenantId(),
+                    'username' => JwtAuthentication::getClaim('sub'),
+                    'ip' => ClientInfo::ip(),
+                ]);
+            });
             \Sentry\captureException($e);
         }
     }


### PR DESCRIPTION
Info:

`tenantId` ist der Hauptgrund für die Änderung - die brauch ich einfach oft, und wär toll im sentry mit dabei zu haben

`$_SERVER['SERVER_NAME']` ist in der AWS immer leerstring - darum weg damit

Claim `sub` gibts im JWT aktuell noch nicht, wird aber zum user werden, wenn employee login implementiert wird

IP is vielleicht mal praktisch weil man in den AWS logs danach suchen kann