### PR TITLE
feat: add slow query logging

### DIFF
--- a/src/DataSource/Mysql/MysqlMigration.php
+++ b/src/DataSource/Mysql/MysqlMigration.php
@@ -127,6 +127,20 @@ class MysqlMigration
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;';
         Mysql::executeRaw($sql);
 
+        $sql = 'CREATE TABLE IF NOT EXISTS `slow_query` (
+            `id` char(36) NOT NULL,
+            `tenant_id` varchar(255) NOT NULL,
+            `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            `milliseconds` int(11) NOT NULL,
+            `query` longtext NOT NULL,
+            `timings` longtext NOT NULL,
+            `ip` varchar(255) NOT NULL,
+            `user_agent` varchar(255) NOT NULL,
+            PRIMARY KEY (`tenant_id`,`id`),
+            KEY `milliseconds` (`milliseconds`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4';
+        Mysql::executeRaw($sql);
+
         $sql = 'SET sql_notes = 1';
         Mysql::executeRaw($sql);
     }

--- a/src/DataSource/Mysql/MysqlMigration.php
+++ b/src/DataSource/Mysql/MysqlMigration.php
@@ -130,12 +130,12 @@ class MysqlMigration
         $sql = 'CREATE TABLE IF NOT EXISTS `slow_query` (
             `id` char(36) NOT NULL,
             `tenant_id` varchar(255) NOT NULL,
-            `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             `milliseconds` int(11) NOT NULL,
             `query` longtext NOT NULL,
             `timings` longtext NOT NULL,
             `ip` varchar(255) NOT NULL,
             `user_agent` varchar(255) NOT NULL,
+            `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (`tenant_id`,`id`),
             KEY `milliseconds` (`milliseconds`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4';

--- a/src/GraphCool.php
+++ b/src/GraphCool.php
@@ -11,8 +11,6 @@ use GraphQL\GraphQL;
 use GraphQL\Type\Schema;
 use JsonException;
 use Mrap\GraphCool\DataSource\DB;
-use Mrap\GraphCool\DataSource\Mysql\Mysql;
-use Mrap\GraphCool\DataSource\Mysql\MysqlConnector;
 use Mrap\GraphCool\Definition\Script;
 use Mrap\GraphCool\Types\MutationType;
 use Mrap\GraphCool\Types\QueryType;
@@ -55,6 +53,7 @@ class GraphCool
         $instance->sendResponse($result);
 
         static::shutdown();
+        StopWatch::log(json_encode($request ?? $result));
     }
 
     public static function reset(): void
@@ -154,6 +153,7 @@ class GraphCool
      */
     protected function sendResponse(array $response): void
     {
+        StopWatch::start(__METHOD__);
         header('Content-Type: application/json');
         $env = Env::get('APP_ENV');
         if ($env === 'local' || $env === 'test' || $env === 'staging') {
@@ -166,6 +166,7 @@ class GraphCool
             echo '{"errors":[[{"message":"Internal server error"}]]}';
         }
         $this->finishRequest();
+        StopWatch::stop(__METHOD__);
     }
 
     /**
@@ -247,9 +248,11 @@ class GraphCool
 
     protected static function shutdown(): void
     {
+        StopWatch::start(__METHOD__);
         foreach (static::$shutdown as $closure) {
             $closure();
         }
+        StopWatch::stop(__METHOD__);
     }
 
     protected static function scheduler(): Scheduler


### PR DESCRIPTION
All GraphQL queries/requests that take longer than 2 seconds to complete, will be logged to a database table - including performance data.