### PR TITLE
feature: new type loader (part 1)

### DIFF
--- a/src/Types/BaseType.php
+++ b/src/Types/BaseType.php
@@ -3,7 +3,6 @@
 namespace Mrap\GraphCool\Types;
 
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
 use Mrap\GraphCool\Definition\Model;
 use Mrap\GraphCool\Definition\Relation;
 use function Mrap\GraphCool\model;
@@ -11,15 +10,15 @@ use function Mrap\GraphCool\model;
 class BaseType extends ObjectType
 {
 
-    protected function exportArgs(string $name, Model $model, TypeLoader $typeLoader): array
+    protected function exportArgs(string $name, Model $model): array
     {
         $args = [
-            'type' => Type::nonNull($typeLoader->load('_ExportFile')),
-            'where' => $typeLoader->load('_' . $name . 'WhereConditions'),
-            'orderBy' => Type::listOf(Type::nonNull($typeLoader->load('_' . $name . 'OrderByClause'))),
+            'type' => Type::nonNull(Type::get('_ExportFile')),
+            'where' => Type::get('_' . $name . 'WhereConditions'),
+            'orderBy' => Type::listOf(Type::nonNull(Type::get('_' . $name . 'OrderByClause'))),
             'search' => Type::string(),
             'searchLoosely' => Type::string(),
-            'columns' => Type::nonNull(Type::listOf(Type::nonNull($typeLoader->load('_' . $name . 'ColumnMapping')))),
+            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::get('_' . $name . 'ColumnMapping')))),
         ];
 
         foreach (get_object_vars($model) as $key => $relation) {
@@ -28,28 +27,28 @@ class BaseType extends ObjectType
             }
             if ($relation->type === Relation::BELONGS_TO || $relation->type === Relation::HAS_ONE) {
                 $args[$key] = Type::listOf(
-                    Type::nonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeColumnMapping'))
+                    Type::nonNull(Type::get('_' . $name . '__' . $key . 'EdgeColumnMapping'))
                 );
             }
             if ($relation->type === Relation::BELONGS_TO_MANY) {
                 $args[$key] = Type::listOf(
-                    Type::nonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeSelector'))
+                    Type::nonNull(Type::get('_' . $name . '__' . $key . 'EdgeSelector'))
                 );
             }
-            $args['where' . ucfirst($key)] = $typeLoader->load('_' . $relation->name . 'WhereConditions');
+            $args['where' . ucfirst($key)] = Type::get('_' . $relation->name . 'WhereConditions');
         }
-        $args['result'] = $typeLoader->load('_Result');
-        $args['_timezone'] = $typeLoader->load('_TimezoneOffset');
+        $args['result'] = Type::get('_Result');
+        $args['_timezone'] = Type::get('_TimezoneOffset');
         return $args;
     }
 
-    protected function importArgs(string $name, TypeLoader $typeLoader): array
+    protected function importArgs(string $name): array
     {
         $args = [
-            'file' => $typeLoader->load('_Upload'),
+            'file' => Type::get('_Upload'),
             'data_base64' => Type::string(),
-            'columns' => Type::nonNull(Type::listOf(Type::nonNull($typeLoader->load('_' . $name . 'ColumnMapping')))),
-            '_timezone' => $typeLoader->load('_TimezoneOffset'),
+            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::get('_' . $name . 'ColumnMapping')))),
+            '_timezone' => Type::get('_TimezoneOffset'),
         ];
         $model = model($name);
         foreach ($model as $key => $relation) {
@@ -58,7 +57,7 @@ class BaseType extends ObjectType
             }
             if ($relation->type === Relation::BELONGS_TO_MANY) {
                 $args[$key] = Type::listOf(
-                    type::nonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeReducedSelector'))
+                    Type::nonNull(Type::get('_' . $name . '__' . $key . 'EdgeReducedSelector'))
                 );
             }
         }

--- a/src/Types/Inputs/ColumnMappingType.php
+++ b/src/Types/Inputs/ColumnMappingType.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class ColumnMappingType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'column' => new NonNull($typeLoader->load(substr($name, 0, -13) . 'Column')),
+            'column' => Type::nonNull(Type::get(substr($name, 0, -13) . 'Column')),
             'label' => Type::string(),
         ];
         $config = [

--- a/src/Types/Inputs/EdgeColumnMappingType.php
+++ b/src/Types/Inputs/EdgeColumnMappingType.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgeColumnMappingType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'column' => new NonNull($typeLoader->load(substr($name, 0, -17) . 'EdgeColumn')),
+            'column' => Type::nonNull(Type::get(substr($name, 0, -17) . 'EdgeColumn')),
             'label' => Type::string(),
         ];
         $config = [

--- a/src/Types/Inputs/EdgeManyInputType.php
+++ b/src/Types/Inputs/EdgeManyInputType.php
@@ -6,8 +6,8 @@ namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
 use Mrap\GraphCool\Definition\Field;
+use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Types\TypeLoader;
 use function Mrap\GraphCool\model;
 
@@ -24,10 +24,10 @@ class EdgeManyInputType extends InputObjectType
         $relation = $model->$key;
 
         $fields = [
-            'where' => new NonNull($typeLoader->load('_' . $relation->name . 'WhereConditions')),
+            'where' => Type::nonNull(Type::get('_' . $relation->name . 'WhereConditions')),
             'search' => Type::string(),
             'searchLoosely' => Type::string(),
-            'mode' => $typeLoader->load('_RelationUpdateMode'),
+            'mode' => Type::get('_RelationUpdateMode'),
         ];
         foreach (get_object_vars($relation) as $fieldKey => $field) {
             if ($field instanceof Field && $field->readonly === false) {

--- a/src/Types/Inputs/EdgeOrderByClauseType.php
+++ b/src/Types/Inputs/EdgeOrderByClauseType.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgeOrderByClauseType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'field' => $typeLoader->load(substr($name, 0, -17) . 'EdgeColumn'),
-            'order' => $typeLoader->load('_SortOrder'),
+            'field' => Type::get(substr($name, 0, -17) . 'EdgeColumn'),
+            'order' => Type::get('_SortOrder'),
         ];
         $config = [
             'name' => $name,

--- a/src/Types/Inputs/EdgeReducedColumnMappingType.php
+++ b/src/Types/Inputs/EdgeReducedColumnMappingType.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgeReducedColumnMappingType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'column' => new NonNull($typeLoader->load(substr($name, 0, -24) . 'EdgeReducedColumn')),
+            'column' => Type::nonNull(Type::get(substr($name, 0, -24) . 'EdgeReducedColumn')),
             'label' => Type::string(),
         ];
         $config = [

--- a/src/Types/Inputs/EdgeReducedSelectorType.php
+++ b/src/Types/Inputs/EdgeReducedSelectorType.php
@@ -5,20 +5,17 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgeReducedSelectorType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'id' => new NonNull(Type::id()),
-            'columns' => new NonNull(
-                new ListOfType(new NonNull($typeLoader->load(substr($name, 0, -15) . 'ReducedColumnMapping')))
+            'id' => Type::nonNull(Type::id()),
+            'columns' => Type::nonNull(
+                Type::listOf(Type::nonNull(Type::get(substr($name, 0, -15) . 'ReducedColumnMapping')))
             ),
         ];
         $config = [

--- a/src/Types/Inputs/EdgeSelectorType.php
+++ b/src/Types/Inputs/EdgeSelectorType.php
@@ -5,20 +5,17 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgeSelectorType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'id' => new NonNull(Type::id()),
-            'columns' => new NonNull(
-                new ListOfType(new NonNull($typeLoader->load(substr($name, 0, -8) . 'ColumnMapping')))
+            'id' => Type::nonNull(Type::id()),
+            'columns' => Type::nonNull(
+                Type::listOf(Type::nonNull(Type::get(substr($name, 0, -8) . 'ColumnMapping')))
             ),
         ];
         $config = [

--- a/src/Types/Inputs/FileType.php
+++ b/src/Types/Inputs/FileType.php
@@ -5,18 +5,16 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class FileType extends InputObjectType
 {
 
-    public function __construct(TypeLoader $typeLoader)
+    public function __construct()
     {
         $fields = [
-            'file' => $typeLoader->load('_Upload')(),
-            'filename' => new NonNull(Type::string()),
+            'file' => Type::get('_Upload'),
+            'filename' => Type::nonNull(Type::string()),
             'data_base64' => Type::string(),
         ];
         $config = [

--- a/src/Types/Inputs/OrderByClauseType.php
+++ b/src/Types/Inputs/OrderByClauseType.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class OrderByClauseType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'field' => $typeLoader->load(substr($name, 0, -13) . 'Column')(),
-            'order' => $typeLoader->load('_SortOrder')(),
+            'field' => Type::get(substr($name, 0, -13) . 'Column'),
+            'order' => Type::get('_SortOrder'),
         ];
         $config = [
             'name' => $name,

--- a/src/Types/Inputs/WhereInputType.php
+++ b/src/Types/Inputs/WhereInputType.php
@@ -5,22 +5,21 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\Type;
+use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class WhereInputType extends InputObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $fields = [
-            'column' => $typeLoader->load(substr($name, 0, -15) . 'Column'),
-            'operator' => $typeLoader->load('_SQLOperator')(),
-            'value' => $typeLoader->load('Mixed'),
+            'column' => Type::get(substr($name, 0, -15) . 'Column'),
+            'operator' => Type::get('_SQLOperator'),
+            'value' => Type::get('Mixed'),
             'fulltextSearch' => Type::string(),
-            'AND' => new ListOfType($this),
-            'OR' => new ListOfType($this)
+            'AND' => Type::listOf($this),
+            'OR' => Type::listOf($this)
         ];
         $config = [
             'name' => $name,

--- a/src/Types/Objects/EdgeType.php
+++ b/src/Types/Objects/EdgeType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use Mrap\GraphCool\Definition\Field;
+use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Types\TypeLoader;
 use function Mrap\GraphCool\model;
 
@@ -19,13 +19,13 @@ class EdgeType extends ObjectType
 
         $model = model($names[0]);
         $relation = $model->$key;
-        $type = $typeLoader->load($relation->name);
+        $type = Type::get($relation->name);
         $fields = [];
         foreach ($relation as $fieldKey => $field) {
             if ($field instanceof Field) {
                 $fieldType = $typeLoader->loadForField($field, $names[0] . '__' . $key . '__' . $fieldKey);
                 if ($field->null === false) {
-                    $fieldType = new NonNull($fieldType);
+                    $fieldType = Type::nonNull($fieldType);
                 }
                 $fields[$fieldKey] = [
                     'type' => $fieldType

--- a/src/Types/Objects/EdgesType.php
+++ b/src/Types/Objects/EdgesType.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class EdgesType extends ObjectType
 {
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $config = [
             'name' => $name,
             'description' => 'A paginated list of ' . substr($name, 1, -5) . ' relations.',
             'fields' => [
-                'paginatorInfo' => $typeLoader->load('_PaginatorInfo'),
-                'edges' => new ListOfType(new NonNull($typeLoader->load(substr($name, 0, -1)))),
+                'paginatorInfo' => Type::get('_PaginatorInfo'),
+                'edges' => Type::listOf(Type::nonNull(Type::get(substr($name, 0, -1)))),
             ],
         ];
         parent::__construct($config);

--- a/src/Types/Objects/HistoryType.php
+++ b/src/Types/Objects/HistoryType.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Objects;
 
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class HistoryType extends ObjectType
 {
 
-    public function __construct(TypeLoader $typeLoader)
+    public function __construct()
     {
         $config = [
             'name' => '_History',
@@ -23,11 +22,11 @@ class HistoryType extends ObjectType
                 'sub' => Type::string(),
                 'ip' => Type::string(),
                 'user_agent' => Type::string(),
-                'change_type' => $typeLoader->load('_History_ChangeType'),
+                'change_type' => Type::get('_History_ChangeType'),
                 'changes' => Type::nonNull(Type::string()),
                 'preceding_hash' => Type::string(),
                 'hash' => Type::nonNull(Type::string()),
-                'created_at' => Type::nonNull($typeLoader->load('_DateTime')),
+                'created_at' => Type::nonNull(Type::get('_DateTime')),
             ],
         ];
         ksort($config['fields']);

--- a/src/Types/Objects/ImportPreviewType.php
+++ b/src/Types/Objects/ImportPreviewType.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
+use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class ImportPreviewType extends ObjectType
@@ -19,8 +17,8 @@ class ImportPreviewType extends ObjectType
             'name' => $name,
             'description' => 'A preview of a ' . $typeName . ' import.',
             'fields' => [
-                'data' => new ListOfType(new NonNull($typeLoader->load($typeName))),
-                'errors' => Type::listOf(Type::nonNull($typeLoader->load('_ImportError')))
+                'data' => Type::listOf(Type::nonNull(Type::get($typeName))),
+                'errors' => Type::listOf(Type::nonNull(Type::get('_ImportError')))
             ],
         ];
         parent::__construct($config);

--- a/src/Types/Objects/ImportSummaryType.php
+++ b/src/Types/Objects/ImportSummaryType.php
@@ -4,30 +4,27 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class ImportSummaryType extends ObjectType
 {
 
-    public function __construct(TypeLoader $typeLoader)
+    public function __construct()
     {
         $config = [
             'name' => '_ImportSummary',
             'description' => 'Summary of import results, including newly created (inserted), modified existing (updated) and the sum of both (affected).',
             'fields' => [
-                'inserted_rows' => new NonNull(Type::int()),
-                'inserted_ids' => new NonNull(new ListOfType(Type::string())),
-                'updated_rows' => new NonNull(Type::int()),
-                'updated_ids' => new NonNull(new ListOfType(Type::string())),
-                'affected_rows' => new NonNull(Type::int()),
-                'affected_ids' => new NonNull(new ListOfType(Type::string())),
-                'failed_rows' => new NonNull(Type::int()),
-                'failed_row_numbers' => new NonNull(new ListOfType(Type::int())),
-                'errors' => Type::listOf(Type::nonNull($typeLoader->load('_ImportError')))
+                'inserted_rows' => Type::nonNull(Type::int()),
+                'inserted_ids' => Type::nonNull(Type::listOf(Type::string())),
+                'updated_rows' => Type::nonNull(Type::int()),
+                'updated_ids' => Type::nonNull(Type::listOf(Type::string())),
+                'affected_rows' => Type::nonNull(Type::int()),
+                'affected_ids' => Type::nonNull(Type::listOf(Type::string())),
+                'failed_rows' => Type::nonNull(Type::int()),
+                'failed_row_numbers' => Type::nonNull(Type::listOf(Type::int())),
+                'errors' => Type::listOf(Type::nonNull(Type::get('_ImportError')))
             ],
         ];
         parent::__construct($config);

--- a/src/Types/Objects/JobType.php
+++ b/src/Types/Objects/JobType.php
@@ -5,26 +5,25 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Objects;
 
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class JobType extends ObjectType
 {
 
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $config = [
             'name' => $name,
             'fields' => [
                 'id' => Type::nonNull(Type::string()),
                 'worker' => Type::nonNull(Type::string()),
-                'model' => $typeLoader->load('_Model'),
-                'status' => Type::nonNull($typeLoader->load('_Job_Status')),
-                'result' => $typeLoader->load($this->getResultType($name)),
-                'run_at' => $typeLoader->load('_DateTime'),
-                'created_at' => Type::nonNull($typeLoader->load('_DateTime')),
-                'started_at' => $typeLoader->load('_DateTime'),
-                'finished_at' => $typeLoader->load('_DateTime'),
+                'model' => Type::get('_Model'),
+                'status' => Type::nonNull(Type::get('_Job_Status')),
+                'result' => Type::get($this->getResultType($name)),
+                'run_at' => Type::get('_DateTime'),
+                'created_at' => Type::nonNull(Type::get('_DateTime')),
+                'started_at' => Type::get('_DateTime'),
+                'finished_at' => Type::get('_DateTime'),
             ],
         ];
         ksort($config['fields']);

--- a/src/Types/Objects/ModelType.php
+++ b/src/Types/Objects/ModelType.php
@@ -8,10 +8,10 @@ use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Type\Definition\Type;
 use Mrap\GraphCool\Definition\Field;
 use Mrap\GraphCool\Definition\Model;
 use Mrap\GraphCool\Definition\Relation;
+use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Types\TypeLoader;
 use stdClass;
 use function Mrap\GraphCool\model;
@@ -40,6 +40,7 @@ class ModelType extends ObjectType
                     $args = [
                         'first' => Type::int(),
                         'page' => Type::int(),
+                        // TODO: replace typeloader with Type::get
                         'where' => $typeLoader->load('_' . $name . '__' . $key . 'EdgeWhereConditions'),
                         'orderBy' => new ListOfType(
                             new NonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeOrderByClause', null, $this))

--- a/src/Types/Objects/ModelType.php
+++ b/src/Types/Objects/ModelType.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\Definition\Field;
@@ -36,14 +34,14 @@ class ModelType extends ObjectType
                 if ($field->type === Relation::BELONGS_TO || $field->type === Relation::HAS_ONE) {
                     $type = $typeLoader->load('_' . $name . '__' . $key . 'Edge');
                 } elseif ($field->type === Relation::HAS_MANY || $field->type === Relation::BELONGS_TO_MANY) {
-                    $type = $typeLoader->load('_' . $name . '__' . $key . 'Edges', null, $this);
+                    $type = $typeLoader->load('_' . $name . '__' . $key . 'Edges');
                     $args = [
                         'first' => Type::int(),
                         'page' => Type::int(),
                         // TODO: replace typeloader with Type::get
                         'where' => $typeLoader->load('_' . $name . '__' . $key . 'EdgeWhereConditions'),
-                        'orderBy' => new ListOfType(
-                            new NonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeOrderByClause', null, $this))
+                        'orderBy' => Type::listOf(
+                            Type::nonNull($typeLoader->load('_' . $name . '__' . $key . 'EdgeOrderByClause'))
                         ),
                         'search' => Type::string(),
                         'searchLoosely' => Type::string(),
@@ -58,7 +56,7 @@ class ModelType extends ObjectType
                 }
                 $type = $typeLoader->loadForField($field, $name . '__' . $key);
                 if ($field->null === false) {
-                    $type = new NonNull($type);
+                    $type = Type::nonNull($type);
                 }
             }
             $typeConfig = [

--- a/src/Types/Objects/PaginatorType.php
+++ b/src/Types/Objects/PaginatorType.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types\Objects;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
-use Mrap\GraphCool\Types\TypeLoader;
+use Mrap\GraphCool\Types\Type;
 
 class PaginatorType extends ObjectType
 {
-    public function __construct(string $name, TypeLoader $typeLoader)
+    public function __construct(string $name)
     {
         $typeName = substr($name, 1, -9);
         if (str_ends_with($typeName, '_Job')) {
@@ -24,8 +22,8 @@ class PaginatorType extends ObjectType
             'name' => $name,
             'description' => 'A paginated list of ' . $typeName . ' items.',
             'fields' => [
-                'paginatorInfo' => $typeLoader->load('_PaginatorInfo'),
-                'data' => new ListOfType(new NonNull($typeLoader->load($typeName)))
+                'paginatorInfo' => Type::get('_PaginatorInfo'),
+                'data' => Type::listOf(Type::nonNull(Type::get($typeName)))
             ],
         ];
         parent::__construct($config);

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mrap\GraphCool\Types;
+
+use GraphQL\Type\Definition\NullableType;
+use GraphQL\Type\Definition\Type as BaseType;
+
+abstract class Type extends BaseType implements NullableType
+{
+    protected static array $types = [];
+
+    protected static TypeLoader $typeLoader;
+
+    // TODO: change return type to self
+    public static function get(string $name): NullableType
+    {
+        if (!isset(static::$types[$name])) {
+            static::$types[$name] = static::create($name);
+        }
+        return static::$types[$name];
+    }
+
+    protected static function create(string $name): NullableType
+    {
+        // TODO: stop using TypeLoader, implement more dynamic/generic type loading in here
+        if (!isset(static::$typeLoader)) {
+            static::$typeLoader = new TypeLoader();
+        }
+        return static::$typeLoader->create($name);
+    }
+
+}

--- a/src/Types/TypeLoader.php
+++ b/src/Types/TypeLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Types;
 
+use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\Type;
 use MLL\GraphQLScalars\MixedScalar;
 use Mrap\GraphCool\Definition\Field;
@@ -59,6 +60,9 @@ use Mrap\GraphCool\Types\Scalars\TimezoneOffset;
 use Mrap\GraphCool\Types\Scalars\Upload;
 use RuntimeException;
 
+/**
+ * @deprecated
+ */
 class TypeLoader
 {
     /** @var string[] */
@@ -106,7 +110,7 @@ class TypeLoader
         static::$registry[$name] = $classname;
     }
 
-    public function loadForField(Field $field, string $name = null, bool $input = false): Type
+    public function loadForField(Field $field, string $name = null, bool $input = false): NullableType
     {
         return match ($field->type) {
             default => Type::string(),
@@ -135,17 +139,14 @@ class TypeLoader
         };
     }
 
-    public function load(string $name, ?ModelType $subType = null, ?ModelType $parentType = null): callable
+    public function load(string $name): callable
     {
         return function () use ($name) {
-            if (!isset($this->types[$name])) {
-                $this->types[$name] = $this->create($name);
-            }
-            return $this->types[$name];
+            return \Mrap\GraphCool\Types\Type::get($name);
         };
     }
 
-    protected function create(string $name): Type
+    public function create(string $name): NullableType
     {
         if (isset(static::$registry[$name])) {
             $classname = static::$registry[$name];
@@ -160,7 +161,7 @@ class TypeLoader
         return new ModelType($name, $this);
     }
 
-    protected function createSpecial(string $name): Type
+    protected function createSpecial(string $name): NullableType
     {
         if (str_ends_with($name, 'Paginator')) {
             return new PaginatorType($name, $this);
@@ -199,7 +200,7 @@ class TypeLoader
             return new EdgeColumnMappingType($name, $this);
         }
         if (str_ends_with($name, 'ColumnMapping')) {
-            return new ColumnMappingType($name, $this);
+            return new ColumnMappingType($name);
         }
         if (str_ends_with($name, 'Column')) {
             return new ColumnType($name, $this);

--- a/src/Types/TypeLoader.php
+++ b/src/Types/TypeLoader.php
@@ -164,16 +164,16 @@ class TypeLoader
     protected function createSpecial(string $name): NullableType
     {
         if (str_ends_with($name, 'Paginator')) {
-            return new PaginatorType($name, $this);
+            return new PaginatorType($name);
         }
         if (str_ends_with($name, 'Edges')) {
-            return new EdgesType($name, $this);
+            return new EdgesType($name);
         }
         if (str_ends_with($name, 'Edge')) {
             return new EdgeType($name, $this);
         }
         if (str_ends_with($name, 'EdgeOrderByClause')) {
-            return new EdgeOrderByClauseType($name, $this);
+            return new EdgeOrderByClauseType($name);
         }
         if (str_ends_with($name, 'EdgeReducedColumn')) {
             return new EdgeReducedColumnType($name, $this);
@@ -182,22 +182,22 @@ class TypeLoader
             return new EdgeColumnType($name, $this);
         }
         if (str_ends_with($name, 'WhereConditions')) {
-            return new WhereInputType($name, $this);
+            return new WhereInputType($name);
         }
         if (str_ends_with($name, 'OrderByClause')) {
-            return new OrderByClauseType($name, $this);
+            return new OrderByClauseType($name);
         }
         if (str_ends_with($name, 'EdgeReducedSelector')) {
-            return new EdgeReducedSelectorType($name, $this);
+            return new EdgeReducedSelectorType($name);
         }
         if (str_ends_with($name, 'EdgeSelector')) {
-            return new EdgeSelectorType($name, $this);
+            return new EdgeSelectorType($name);
         }
         if (str_ends_with($name, 'EdgeReducedColumnMapping')) {
-            return new EdgeReducedColumnMappingType($name, $this);
+            return new EdgeReducedColumnMappingType($name);
         }
         if (str_ends_with($name, 'EdgeColumnMapping')) {
-            return new EdgeColumnMappingType($name, $this);
+            return new EdgeColumnMappingType($name);
         }
         if (str_ends_with($name, 'ColumnMapping')) {
             return new ColumnMappingType($name);
@@ -218,7 +218,7 @@ class TypeLoader
             return new ModelInputType($name, $this);
         }
         if (str_ends_with($name, 'Job') && $name !== '_Job') {
-            return new JobType($name, $this);
+            return new JobType($name);
         }
         if (str_ends_with($name, 'ImportPreview')) {
             return new ImportPreviewType($name, $this);


### PR DESCRIPTION
The old `$typeLoader->load($name)` shall be replaced with a new `Type::get($name)` method, which as a first step shall only be a wrapper for the old TypeLoader.

Ultimately the old TypeLoader shall be replaced or refactored entirely - but that's another PR.

ModelType has not been updated yet - that would cause memory issues, which need to be resolved first. There's probably need for an additional Closure somewhere.

$typeLoader->loadForField() is still to do as well - but the PR is already large enough as is.