### PR TITLE
refactor paginator class

### DIFF
--- a/src/Queries/ListModel.php
+++ b/src/Queries/ListModel.php
@@ -7,7 +7,6 @@ namespace Mrap\GraphCool\Queries;
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\DataSource\DB;
 use Mrap\GraphCool\Definition\ModelBased;
-use Mrap\GraphCool\Definition\ModelQuery;
 use Mrap\GraphCool\Definition\Query;
 use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Type;
@@ -49,7 +48,7 @@ class ListModel extends Query
         $args['_timezone'] = Type::get('_TimezoneOffset');
 
         $this->config = [
-            'type' => Type::get('_' . $model . 'Paginator'),
+            'type' => Type::paginatedList($model),
             'description' => 'Get a paginated list of ' . $model . 's filtered by given where clauses.',
             'args' => $args
         ];

--- a/src/Types/Inputs/WhereConditions.php
+++ b/src/Types/Inputs/WhereConditions.php
@@ -7,15 +7,15 @@ namespace Mrap\GraphCool\Types\Inputs;
 use GraphQL\Type\Definition\InputObjectType;
 use Mrap\GraphCool\Types\Type;
 
-class WhereInputType extends InputObjectType
+class WhereConditions extends InputObjectType
 {
 
-    public function __construct(string $name)
+    public function __construct(string $wrappedType)
     {
         parent::__construct([
-            'name' => $name,
+            'name' => '_' . $wrappedType . 'WhereConditions',
             'fields' => fn() => [
-                'column' => Type::get(substr($name, 0, -15) . 'Column'),
+                'column' => Type::get('_' . $wrappedType . 'Column'),
                 'operator' => Type::get('_SQLOperator'),
                 'value' => Type::get('Mixed'),
                 'fulltextSearch' => Type::string(),

--- a/src/Types/Objects/ModelPaginator.php
+++ b/src/Types/Objects/ModelPaginator.php
@@ -7,15 +7,15 @@ namespace Mrap\GraphCool\Types\Objects;
 use GraphQL\Type\Definition\ObjectType;
 use Mrap\GraphCool\Types\Type;
 
-class PaginatorType extends ObjectType
+class ModelPaginator extends ObjectType
 {
-    public function __construct(string $name)
+
+    public function __construct(string $wrappedType)
     {
-        $typeName = substr($name, 1, -9);
         parent::__construct([
-            'name' => $name,
-            'description' => 'A paginated list of ' . $typeName . ' items.',
-            'fields' => fn() => $this->fieldConfig($typeName),
+            'name' => '_' . $wrappedType . 'Paginator',
+            'description' => 'A paginated list of ' . $wrappedType . ' items.',
+            'fields' => fn() => $this->fieldConfig($wrappedType),
         ]);
     }
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -41,7 +41,7 @@ use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\FileType;
 use Mrap\GraphCool\Types\Inputs\ModelInputType;
 use Mrap\GraphCool\Types\Inputs\OrderByClauseType;
-use Mrap\GraphCool\Types\Inputs\WhereInputType;
+use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\EdgesType;
 use Mrap\GraphCool\Types\Objects\EdgeType;
 use Mrap\GraphCool\Types\Objects\FileExportType;
@@ -52,7 +52,7 @@ use Mrap\GraphCool\Types\Objects\ImportSummaryType;
 use Mrap\GraphCool\Types\Objects\JobType;
 use Mrap\GraphCool\Types\Objects\ModelType;
 use Mrap\GraphCool\Types\Objects\PaginatorInfoType;
-use Mrap\GraphCool\Types\Objects\PaginatorType;
+use Mrap\GraphCool\Types\Objects\ModelPaginator;
 use Mrap\GraphCool\Types\Objects\UpdateManyResult;
 use Mrap\GraphCool\Types\Scalars\Date;
 use Mrap\GraphCool\Types\Scalars\DateTime;
@@ -72,6 +72,19 @@ abstract class Type extends BaseType implements NullableType
         }
         return static::$types[$name];
     }
+
+    public static function paginatedList(BaseType|string $wrappedType): ModelPaginator
+    {
+        if (is_string($wrappedType)) {
+            $name = $wrappedType;
+        } else {
+            $name = $wrappedType->name;
+        }
+        $type = new ModelPaginator($name);
+        static::$types[$type->name] = $type;
+        return $type;
+    }
+
 
     protected static function create(string $name): NullableType
     {
@@ -113,11 +126,14 @@ abstract class Type extends BaseType implements NullableType
     protected static function createDynamic(string $name): NullableType
     {
         // TODO: this could probably be wrapped types?
+
         if (!str_starts_with($name, '_')) {
             return new ModelType($name);
         }
+
+        // TODO: probably can be removed after importjob, exportjob and history are models
         if (str_ends_with($name, 'Paginator')) {
-            return new PaginatorType($name);
+            return new ModelPaginator(substr($name, 1, -9));
         }
         if (str_ends_with($name, 'Edges')) {
             return new EdgesType($name);
@@ -135,7 +151,7 @@ abstract class Type extends BaseType implements NullableType
             return new EdgeColumnType($name);
         }
         if (str_ends_with($name, 'WhereConditions')) {
-            return new WhereInputType($name);
+            return new WhereConditions(substr($name, 1, -15));
         }
         if (str_ends_with($name, 'OrderByClause')) {
             return new OrderByClauseType($name);

--- a/tests/Types/Inputs/WhereInputTypeTest.php
+++ b/tests/Types/Inputs/WhereInputTypeTest.php
@@ -6,7 +6,7 @@ namespace Mrap\GraphCool\Tests\Types\Inputs;
 
 use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
-use Mrap\GraphCool\Types\Inputs\WhereInputType;
+use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class WhereInputTypeTest extends TestCase
@@ -14,7 +14,7 @@ class WhereInputTypeTest extends TestCase
     public function testConstructor(): void
     {
         require_once($this->dataPath().'/app/Models/DummyModel.php');
-        $input = new WhereInputType('_DummyModelWhereConditions', new TypeLoader());
+        $input = new WhereConditions('_DummyModelWhereConditions', new TypeLoader());
         self::assertInstanceOf(InputType::class, $input);
     }
 }

--- a/tests/Types/Objects/PaginatorTypeTest.php
+++ b/tests/Types/Objects/PaginatorTypeTest.php
@@ -7,20 +7,20 @@ namespace Mrap\GraphCool\Tests\Types\Objects;
 use GraphQL\Type\Definition\ObjectType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Objects\EdgeType;
-use Mrap\GraphCool\Types\Objects\PaginatorType;
+use Mrap\GraphCool\Types\Objects\ModelPaginator;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class PaginatorTypeTest extends TestCase
 {
     public function testConstructor(): void
     {
-        $object = new PaginatorType('_DummyModelPaginator', new TypeLoader());
+        $object = new ModelPaginator('_DummyModelPaginator', new TypeLoader());
         self::assertInstanceOf(ObjectType::class, $object);
     }
 
     public function testConstructorJob(): void
     {
-        $object = new PaginatorType('_Import_JobPaginator', new TypeLoader());
+        $object = new ModelPaginator('_Import_JobPaginator', new TypeLoader());
         self::assertInstanceOf(ObjectType::class, $object);
     }
 }

--- a/tests/Types/TypeLoaderTest.php
+++ b/tests/Types/TypeLoaderTest.php
@@ -22,13 +22,13 @@ use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\ModelInputType;
 use Mrap\GraphCool\Types\Inputs\OrderByClauseType;
-use Mrap\GraphCool\Types\Inputs\WhereInputType;
+use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\EdgesType;
 use Mrap\GraphCool\Types\Objects\EdgeType;
 use Mrap\GraphCool\Types\Objects\ImportSummaryType;
 use Mrap\GraphCool\Types\Objects\JobType;
 use Mrap\GraphCool\Types\Objects\ModelType;
-use Mrap\GraphCool\Types\Objects\PaginatorType;
+use Mrap\GraphCool\Types\Objects\ModelPaginator;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class TypeLoaderTest extends TestCase
@@ -129,7 +129,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModelPaginator')();
-        self::assertInstanceOf(PaginatorType::class, $result);
+        self::assertInstanceOf(ModelPaginator::class, $result);
     }
 
     public function testCreateEdges(): void
@@ -171,7 +171,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModelWhereConditions')();
-        self::assertInstanceOf(WhereInputType::class, $result);
+        self::assertInstanceOf(WhereConditions::class, $result);
     }
 
     public function testCreateOrderByClause(): void


### PR DESCRIPTION
Refactoring of `WhereConditions` and `ModelPaginator` - first step

To complete this, importjob, exportjob and History have to become models first.

