### PR TITLE
Refactor column mapping and order by clause

### DIFF
--- a/src/Definition/ModelBased.php
+++ b/src/Definition/ModelBased.php
@@ -15,10 +15,10 @@ trait ModelBased
         $args = [
             'type' => Type::nonNull(Type::get('_ExportFile')),
             'where' => Type::get('_' . $name . 'WhereConditions'),
-            'orderBy' => Type::listOf(Type::nonNull(Type::get('_' . $name . 'OrderByClause'))),
+            'orderBy' => Type::listOf(Type::nonNull(Type::orderByClause($name ))),
             'search' => Type::string(),
             'searchLoosely' => Type::string(),
-            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::get('_' . $name . 'ColumnMapping')))),
+            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::columnMapping($name)))),
         ];
 
         foreach (get_object_vars($model) as $key => $relation) {
@@ -47,7 +47,7 @@ trait ModelBased
         $args = [
             'file' => Type::get('_Upload'),
             'data_base64' => Type::string(),
-            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::get('_' . $name . 'ColumnMapping')))),
+            'columns' => Type::nonNull(Type::listOf(Type::nonNull(Type::columnMapping($name)))),
             '_timezone' => Type::get('_TimezoneOffset'),
         ];
         $model = model($name);

--- a/src/Queries/ListModel.php
+++ b/src/Queries/ListModel.php
@@ -41,7 +41,7 @@ class ListModel extends Query
             }
             $args['where' . ucfirst($key)] = Type::get('_' . $relation->name . 'WhereConditions');
         }
-        $args['orderBy'] = Type::listOf(Type::nonNull(Type::get('_' . $model . 'OrderByClause')));
+        $args['orderBy'] = Type::listOf(Type::nonNull(Type::orderByClause($model)));
         $args['search'] = Type::string();
         $args['searchLoosely'] = Type::string();
         $args['result'] = Type::get('_Result');

--- a/src/Types/Inputs/ModelColumnMapping.php
+++ b/src/Types/Inputs/ModelColumnMapping.php
@@ -7,15 +7,15 @@ namespace Mrap\GraphCool\Types\Inputs;
 use GraphQL\Type\Definition\InputObjectType;
 use Mrap\GraphCool\Types\Type;
 
-class ColumnMappingType extends InputObjectType
+class ModelColumnMapping extends InputObjectType
 {
 
-    public function __construct(string $name)
+    public function __construct(string $model)
     {
         parent::__construct([
-            'name' => $name,
+            'name' => '_' . $model . 'ColumnMapping',
             'fields' => fn() => [
-                'column' => Type::nonNull(Type::column(substr($name, 1, -13))),
+                'column' => Type::nonNull(Type::column($model)),
                 'label' => Type::string(),
             ],
         ]);

--- a/src/Types/Inputs/OrderByClause.php
+++ b/src/Types/Inputs/OrderByClause.php
@@ -7,15 +7,15 @@ namespace Mrap\GraphCool\Types\Inputs;
 use GraphQL\Type\Definition\InputObjectType;
 use Mrap\GraphCool\Types\Type;
 
-class OrderByClauseType extends InputObjectType
+class OrderByClause extends InputObjectType
 {
 
     public function __construct(string $name)
     {
         parent::__construct([
-            'name' => $name,
+            'name' => '_' . $name . 'OrderByClause',
             'fields' => fn() => [
-                'field' => Type::column(substr($name, 1, -13)),
+                'field' => Type::column($name),
                 'order' => Type::get('_SortOrder'),
             ],
         ]);

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -32,7 +32,7 @@ use Mrap\GraphCool\Types\Enums\SheetFileEnumType;
 use Mrap\GraphCool\Types\Enums\SortOrderEnumType;
 use Mrap\GraphCool\Types\Enums\SQLOperatorType;
 use Mrap\GraphCool\Types\Enums\WhereModeEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\EdgeColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
@@ -42,7 +42,7 @@ use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\FileType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\OrderByClause;
 use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\ModelEdgePaginator;
 use Mrap\GraphCool\Types\Objects\ModelEdge;
@@ -160,9 +160,12 @@ abstract class Type extends BaseType implements NullableType
         if (str_ends_with($name, 'WhereConditions')) {
             return new WhereConditions(substr($name, 1, -15));
         }
+
+        // TODO: probably can be removed after importjob, exportjob and history are models
         if (str_ends_with($name, 'OrderByClause')) {
-            return new OrderByClauseType($name);
+            return new OrderByClause(substr($name, 1, -13));
         }
+
         if (str_ends_with($name, 'EdgeReducedSelector')) {
             return new EdgeReducedSelectorType($name);
         }
@@ -174,9 +177,6 @@ abstract class Type extends BaseType implements NullableType
         }
         if (str_ends_with($name, 'EdgeColumnMapping')) {
             return new EdgeColumnMappingType($name);
-        }
-        if (str_ends_with($name, 'ColumnMapping')) {
-            return new ColumnMappingType($name);
         }
 
         if (str_ends_with($name, 'Column')) {
@@ -268,6 +268,19 @@ abstract class Type extends BaseType implements NullableType
         return $type;
     }
 
+    public static function columnMapping(string $model): ModelColumnMapping
+    {
+        /** @var ModelColumnMapping $type */
+        $type = static::cache(new ModelColumnMapping($model));
+        return $type;
+    }
+
+    public static function orderByClause(string $name): OrderByClause
+    {
+        /** @var OrderByClause $type */
+        $type = static::cache(new OrderByClause($name));
+        return $type;
+    }
 
     public static function relation(Relation $relation): ?NullableType
     {

--- a/tests/Types/Inputs/ColumnMappingTypeTest.php
+++ b/tests/Types/Inputs/ColumnMappingTypeTest.php
@@ -9,14 +9,14 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class ColumnMappingTypeTest extends TestCase
 {
     public function testConstructor(): void
     {
-        $enum = new ColumnMappingType('_DummyModelColumnMapping', new TypeLoader());
+        $enum = new ModelColumnMapping('_DummyModelColumnMapping', new TypeLoader());
         self::assertInstanceOf(InputType::class, $enum);
     }
 }

--- a/tests/Types/Inputs/EdgeInputTypeTest.php
+++ b/tests/Types/Inputs/EdgeInputTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\TypeLoader;
 

--- a/tests/Types/Inputs/EdgeManyInputTypeTest.php
+++ b/tests/Types/Inputs/EdgeManyInputTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
 use Mrap\GraphCool\Types\TypeLoader;

--- a/tests/Types/Inputs/EdgeOrderByClauseTypeTest.php
+++ b/tests/Types/Inputs/EdgeOrderByClauseTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
 use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;

--- a/tests/Types/Inputs/EdgeReducedColumnMappingTypeTest.php
+++ b/tests/Types/Inputs/EdgeReducedColumnMappingTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
 use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;

--- a/tests/Types/Inputs/EdgeReducedSelectorTypeTest.php
+++ b/tests/Types/Inputs/EdgeReducedSelectorTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
 use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;

--- a/tests/Types/Inputs/EdgeSelectorTypeTest.php
+++ b/tests/Types/Inputs/EdgeSelectorTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
 use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;

--- a/tests/Types/Inputs/OrderByClauseTypeTest.php
+++ b/tests/Types/Inputs/OrderByClauseTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Inputs\FileInputType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\OrderByClause;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class OrderByClauseTypeTest extends TestCase
@@ -17,7 +17,7 @@ class OrderByClauseTypeTest extends TestCase
     public function testConstructor(): void
     {
         require_once($this->dataPath().'/app/Models/DummyModel.php');
-        $input = new OrderByClauseType('_DummyModelOrderByClause', new TypeLoader());
+        $input = new OrderByClause('_DummyModelOrderByClause', new TypeLoader());
         self::assertInstanceOf(InputType::class, $input);
     }
 }

--- a/tests/Types/TypeLoaderTest.php
+++ b/tests/Types/TypeLoaderTest.php
@@ -12,7 +12,7 @@ use Mrap\GraphCool\Types\Enums\ModelColumn;
 use Mrap\GraphCool\Types\Enums\DynamicEnumType;
 use Mrap\GraphCool\Types\Enums\EdgeColumnType;
 use Mrap\GraphCool\Types\Enums\EdgeReducedColumnType;
-use Mrap\GraphCool\Types\Inputs\ColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\EdgeColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
@@ -21,7 +21,7 @@ use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\OrderByClause;
 use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\ModelEdgePaginator;
 use Mrap\GraphCool\Types\Objects\ModelEdge;
@@ -178,7 +178,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModelOrderByClause')();
-        self::assertInstanceOf(OrderByClauseType::class, $result);
+        self::assertInstanceOf(OrderByClause::class, $result);
     }
 
     public function testCreateEdgeReducedSelector(): void
@@ -213,7 +213,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModelColumnMapping')();
-        self::assertInstanceOf(ColumnMappingType::class, $result);
+        self::assertInstanceOf(ModelColumnMapping::class, $result);
     }
 
     public function testCreateColumn(): void


### PR DESCRIPTION
* renamed `OrderByClauseType` to `OrderByClause`
* renamed `ColumnMappingType` to `ModelColumnMapping`
* changed both constructors to accept only the model-name as string, and create their full type-name internally
* added a wrapper function in `Type` for the creation of both classes
* replaced instantiations of both classes to use that wrapper instead

Schema before/after has been diff-ed and shows no changes

Depends on https://github.com/mRaPGmbH/GraphCool/pull/23 - ready for review after that has been merged