### PR TITLE
Refactor edge column mapping and order by clause

### DIFF
--- a/src/Definition/ModelBased.php
+++ b/src/Definition/ModelBased.php
@@ -27,7 +27,7 @@ trait ModelBased
             }
             if ($relation->type === Relation::BELONGS_TO || $relation->type === Relation::HAS_ONE) {
                 $args[$key] = Type::listOf(
-                    Type::nonNull(Type::get('_' . $name . '__' . $key . 'EdgeColumnMapping'))
+                    Type::nonNull(Type::columnMapping($relation))
                 );
             }
             if ($relation->type === Relation::BELONGS_TO_MANY) {

--- a/src/Types/Enums/EdgeColumn.php
+++ b/src/Types/Enums/EdgeColumn.php
@@ -5,20 +5,27 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Enums;
 
 use GraphQL\Type\Definition\EnumType;
+use Mrap\GraphCool\Definition\Model;
+use Mrap\GraphCool\Definition\Relation;
 use function Mrap\GraphCool\model;
 
-class EdgeColumnType extends EnumType
+class EdgeColumn extends EnumType
 {
 
-    public function __construct(string $name)
+    public function __construct(Relation $relation)
     {
-        $names = explode('__', substr($name, 1, -10), 2);
-        $parentModel = model($names[0]);
+        $config = [
+            'name' => '_' . $relation->namekey. 'EdgeColumn',
+            'description' => 'Column names of type `' . $relation->name . '` and pivot properties (prefixed with underscore) of the relation `' . $relation->namekey . '`.',
+            'values' => $this->values($relation),
+        ];
+        parent::__construct($config);
+    }
 
-        $relation = $parentModel->{$names[1]};
-
+    protected function values(Relation $relation): array
+    {
         $values = [];
-        foreach ($parentModel->relationFields($names[1]) as $key => $field) {
+        foreach (Model::relationFieldsForRelation($relation) as $key => $field) {
             $upperName = strtoupper($key);
             $values['_' . $upperName] = [
                 'value' => '_' . $key,
@@ -27,7 +34,6 @@ class EdgeColumnType extends EnumType
         }
 
         $model = model($relation->name);
-
         foreach ($model->fields() as $key => $field) {
             $upperName = strtoupper($key);
             $values[$upperName] = [
@@ -36,12 +42,7 @@ class EdgeColumnType extends EnumType
             ];
         }
         ksort($values);
-        $config = [
-            'name' => $name,
-            'description' => 'Column names of type `' . $relation->name . '` and pivot properties (prefixed with underscore) of the relation `' . $names[0] . '.' . $names[1] . '`.',
-            'values' => $values
-        ];
-        parent::__construct($config);
+        return $values;
     }
 
 }

--- a/src/Types/Inputs/EdgeColumnMapping.php
+++ b/src/Types/Inputs/EdgeColumnMapping.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
+use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Type;
 
-class EdgeColumnMappingType extends InputObjectType
+class EdgeColumnMapping extends InputObjectType
 {
 
-    public function __construct(string $name)
+    public function __construct(Relation $relation)
     {
         parent::__construct([
-            'name' => $name,
+            'name' => '_' . $relation->namekey . 'EdgeColumnMapping',
             'fields' => fn() => [
-                'column' => Type::nonNull(Type::get(substr($name, 0, -17) . 'EdgeColumn')),
+                'column' => Type::nonNull(Type::column($relation)),
                 'label' => Type::string(),
             ],
         ]);

--- a/src/Types/Inputs/EdgeOrderByClause.php
+++ b/src/Types/Inputs/EdgeOrderByClause.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Types\Inputs;
 
 use GraphQL\Type\Definition\InputObjectType;
+use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Type;
 
-class EdgeOrderByClauseType extends InputObjectType
+class EdgeOrderByClause extends InputObjectType
 {
 
-    public function __construct(string $name)
+    public function __construct(Relation $relation)
     {
         parent::__construct([
-            'name' => $name,
+            'name' => '_' . $relation->namekey . 'EdgeOrderByClause',
             'fields' => fn() => [
-                'field' => Type::get(substr($name, 0, -17) . 'EdgeColumn'),
+                'field' => Type::column($relation),
                 'order' => Type::get('_SortOrder'),
             ],
         ]);

--- a/src/Types/Inputs/ModelOrderByClause.php
+++ b/src/Types/Inputs/ModelOrderByClause.php
@@ -7,7 +7,7 @@ namespace Mrap\GraphCool\Types\Inputs;
 use GraphQL\Type\Definition\InputObjectType;
 use Mrap\GraphCool\Types\Type;
 
-class OrderByClause extends InputObjectType
+class ModelOrderByClause extends InputObjectType
 {
 
     public function __construct(string $name)

--- a/src/Types/Inputs/WhereConditions.php
+++ b/src/Types/Inputs/WhereConditions.php
@@ -12,10 +12,16 @@ class WhereConditions extends InputObjectType
 
     public function __construct(string $wrappedType)
     {
+        if (str_ends_with($wrappedType, 'Edge')) {
+            // TODO: make this dynamic
+            $column = Type::get('_' . $wrappedType . 'Column');
+        } else {
+            $column = Type::column($wrappedType);
+        }
         parent::__construct([
             'name' => '_' . $wrappedType . 'WhereConditions',
             'fields' => fn() => [
-                'column' => Type::get('_' . $wrappedType . 'Column'),
+                'column' => $column,
                 'operator' => Type::get('_SQLOperator'),
                 'value' => Type::get('Mixed'),
                 'fulltextSearch' => Type::string(),

--- a/src/Types/Objects/ModelType.php
+++ b/src/Types/Objects/ModelType.php
@@ -41,8 +41,6 @@ class ModelType extends ObjectType
                 $fields[$key]['args'] = [
                     'first' => Type::int(),
                     'page' => Type::int(),
-
-                    // TODO: fix EdgeWhereConditions
                     'where' => Type::get('_' . $name . '__' . $key . 'EdgeWhereConditions'),
                     'orderBy' => Type::listOf(
                         Type::nonNull(Type::orderByClause($relation))

--- a/src/Types/Objects/ModelType.php
+++ b/src/Types/Objects/ModelType.php
@@ -41,9 +41,11 @@ class ModelType extends ObjectType
                 $fields[$key]['args'] = [
                     'first' => Type::int(),
                     'page' => Type::int(),
+
+                    // TODO: fix EdgeWhereConditions
                     'where' => Type::get('_' . $name . '__' . $key . 'EdgeWhereConditions'),
                     'orderBy' => Type::listOf(
-                        Type::nonNull(Type::get('_' . $name . '__' . $key . 'EdgeOrderByClause'))
+                        Type::nonNull(Type::orderByClause($relation))
                     ),
                     'search' => Type::string(),
                     'searchLoosely' => Type::string(),

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -15,7 +15,7 @@ use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Enums\CountryCodeEnumType;
 use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
 use Mrap\GraphCool\Types\Enums\DynamicEnumType;
-use Mrap\GraphCool\Types\Enums\EdgeColumnType;
+use Mrap\GraphCool\Types\Enums\EdgeColumn;
 use Mrap\GraphCool\Types\Enums\EdgeReducedColumnType;
 use Mrap\GraphCool\Types\Enums\EntityEnumType;
 use Mrap\GraphCool\Types\Enums\HistoryChangeTypeEnumType;
@@ -33,10 +33,10 @@ use Mrap\GraphCool\Types\Enums\SortOrderEnumType;
 use Mrap\GraphCool\Types\Enums\SQLOperatorType;
 use Mrap\GraphCool\Types\Enums\WhereModeEnumType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
-use Mrap\GraphCool\Types\Inputs\EdgeColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\EdgeColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
@@ -62,6 +62,7 @@ use Mrap\GraphCool\Types\Scalars\Time;
 use Mrap\GraphCool\Types\Scalars\TimezoneOffset;
 use Mrap\GraphCool\Types\Scalars\Upload;
 use RuntimeException;
+use function Mrap\GraphCool\model;
 
 abstract class Type extends BaseType implements NullableType
 {
@@ -148,15 +149,23 @@ abstract class Type extends BaseType implements NullableType
         if (str_ends_with($name, 'Paginator')) {
             return new ModelPaginator(substr($name, 1, -9));
         }
+
+        /*
         if (str_ends_with($name, 'EdgeOrderByClause')) {
-            return new EdgeOrderByClauseType($name);
-        }
+            return new EdgeOrderByClause($name);
+        }*/
+
         if (str_ends_with($name, 'EdgeReducedColumn')) {
             return new EdgeReducedColumnType($name);
         }
+
+        // TODO: remove this once EdgeSelector has been refactored
         if (str_ends_with($name, 'EdgeColumn')) {
-            return new EdgeColumnType($name);
+            $nameParts = explode('__', substr($name, 1, -10), 2);
+            $model = model($nameParts[0]);
+            return static::column($model->{$nameParts[1]});
         }
+
         if (str_ends_with($name, 'WhereConditions')) {
             return new WhereConditions(substr($name, 1, -15));
         }
@@ -175,8 +184,13 @@ abstract class Type extends BaseType implements NullableType
         if (str_ends_with($name, 'EdgeReducedColumnMapping')) {
             return new EdgeReducedColumnMappingType($name);
         }
+
+
+        // TODO: this can be removed after EdgeSelector has been refactored
         if (str_ends_with($name, 'EdgeColumnMapping')) {
-            return new EdgeColumnMappingType($name);
+            $nameParts = explode('__', substr($name, 1, -17), 2);
+            $model = model($nameParts[0]);
+            return static::columnMapping($model->{$nameParts[1]});
         }
 
         if (str_ends_with($name, 'Column')) {
@@ -248,7 +262,7 @@ abstract class Type extends BaseType implements NullableType
         return $type;
     }
 
-    public static function column(BaseType|string $wrappedType): ModelColumn|EnumType|NullableType
+    public static function column(BaseType|string|Relation $wrappedType): ModelColumn|EnumType|NullableType|EdgeColumn
     {
         if ($wrappedType === 'Job_') {
             // TODO: remove once importjob and exportjob are models
@@ -257,6 +271,11 @@ abstract class Type extends BaseType implements NullableType
         if ($wrappedType === 'History_') {
             // TODO: remove once history is a model
             return static::get('_History_Column');
+        }
+        if ($wrappedType instanceof Relation) {
+            /** @var EdgeColumn $type */
+            $type = static::cache(new EdgeColumn($wrappedType));
+            return $type;
         }
         if (is_string($wrappedType)) {
             $name = $wrappedType;
@@ -268,17 +287,27 @@ abstract class Type extends BaseType implements NullableType
         return $type;
     }
 
-    public static function columnMapping(string $model): ModelColumnMapping
+    public static function columnMapping(string|Relation $model): ModelColumnMapping|EdgeColumnMapping
     {
-        /** @var ModelColumnMapping $type */
-        $type = static::cache(new ModelColumnMapping($model));
+        if (is_string($model)) {
+            /** @var ModelColumnMapping $type */
+            $type = static::cache(new ModelColumnMapping($model));
+            return $type;
+        }
+        /** @var EdgeColumnMapping $type */
+        $type = static::cache(new EdgeColumnMapping($model));
         return $type;
     }
 
-    public static function orderByClause(string $name): OrderByClause
+    public static function orderByClause(string|Relation $name): OrderByClause|EdgeOrderByClause
     {
-        /** @var OrderByClause $type */
-        $type = static::cache(new OrderByClause($name));
+        if (is_string($name)) {
+            /** @var OrderByClause $type */
+            $type = static::cache(new OrderByClause($name));
+            return $type;
+        }
+        /** @var EdgeOrderByClause $type */
+        $type = static::cache(new EdgeOrderByClause($name));
         return $type;
     }
 

--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -42,7 +42,7 @@ use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\FileType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClause;
+use Mrap\GraphCool\Types\Inputs\ModelOrderByClause;
 use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\ModelEdgePaginator;
 use Mrap\GraphCool\Types\Objects\ModelEdge;
@@ -172,7 +172,7 @@ abstract class Type extends BaseType implements NullableType
 
         // TODO: probably can be removed after importjob, exportjob and history are models
         if (str_ends_with($name, 'OrderByClause')) {
-            return new OrderByClause(substr($name, 1, -13));
+            return new ModelOrderByClause(substr($name, 1, -13));
         }
 
         if (str_ends_with($name, 'EdgeReducedSelector')) {
@@ -299,11 +299,11 @@ abstract class Type extends BaseType implements NullableType
         return $type;
     }
 
-    public static function orderByClause(string|Relation $name): OrderByClause|EdgeOrderByClause
+    public static function orderByClause(string|Relation $name): ModelOrderByClause|EdgeOrderByClause
     {
         if (is_string($name)) {
-            /** @var OrderByClause $type */
-            $type = static::cache(new OrderByClause($name));
+            /** @var ModelOrderByClause $type */
+            $type = static::cache(new ModelOrderByClause($name));
             return $type;
         }
         /** @var EdgeOrderByClause $type */

--- a/tests/Types/Enums/EdgeColumnTypeTest.php
+++ b/tests/Types/Enums/EdgeColumnTypeTest.php
@@ -6,7 +6,7 @@ namespace Mrap\GraphCool\Tests\Types\Enums;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\EnumValueDefinition;
 use Mrap\GraphCool\Tests\TestCase;
-use Mrap\GraphCool\Types\Enums\EdgeColumnType;
+use Mrap\GraphCool\Types\Enums\EdgeColumn;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class EdgeColumnTypeTest extends TestCase
@@ -14,7 +14,7 @@ class EdgeColumnTypeTest extends TestCase
     public function testConstructor(): void
     {
         require_once($this->dataPath().'/app/Models/DummyModel.php');
-        $enum = new EdgeColumnType('_DummyModel__belongs_to_manyEdgeColumn', new TypeLoader());
+        $enum = new EdgeColumn('_DummyModel__belongs_to_manyEdgeColumn', new TypeLoader());
         self::assertInstanceOf(EnumType::class, $enum);
 
         $columns = [];

--- a/tests/Types/Inputs/EdgeColumnMappingTypeTest.php
+++ b/tests/Types/Inputs/EdgeColumnMappingTypeTest.php
@@ -6,14 +6,14 @@ namespace Mrap\GraphCool\Tests\Types\Inputs;
 
 use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
-use Mrap\GraphCool\Types\Inputs\EdgeColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\EdgeColumnMapping;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class EdgeColumnMappingTypeTest extends TestCase
 {
     public function testConstructor(): void
     {
-        $enum = new EdgeColumnMappingType('_DummyModel__belongs_to_manyColumnMapping', new TypeLoader());
+        $enum = new EdgeColumnMapping('_DummyModel__belongs_to_manyColumnMapping', new TypeLoader());
         self::assertInstanceOf(InputType::class, $enum);
     }
 }

--- a/tests/Types/Inputs/EdgeOrderByClauseTypeTest.php
+++ b/tests/Types/Inputs/EdgeOrderByClauseTypeTest.php
@@ -12,14 +12,14 @@ use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class EdgeOrderByClauseTypeTest extends TestCase
 {
     public function testConstructor(): void
     {
-        $enum = new EdgeOrderByClauseType('_DummyModel__belongs_to_manyEdgeOrderByClause', new TypeLoader());
+        $enum = new EdgeOrderByClause('_DummyModel__belongs_to_manyEdgeOrderByClause', new TypeLoader());
         self::assertInstanceOf(InputType::class, $enum);
     }
 }

--- a/tests/Types/Inputs/EdgeReducedColumnMappingTypeTest.php
+++ b/tests/Types/Inputs/EdgeReducedColumnMappingTypeTest.php
@@ -12,7 +12,7 @@ use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\TypeLoader;
 

--- a/tests/Types/Inputs/EdgeReducedSelectorTypeTest.php
+++ b/tests/Types/Inputs/EdgeReducedSelectorTypeTest.php
@@ -12,7 +12,7 @@ use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\TypeLoader;

--- a/tests/Types/Inputs/EdgeSelectorTypeTest.php
+++ b/tests/Types/Inputs/EdgeSelectorTypeTest.php
@@ -12,7 +12,7 @@ use Mrap\GraphCool\Types\Enums\CurrencyEnumType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;

--- a/tests/Types/Inputs/OrderByClauseTypeTest.php
+++ b/tests/Types/Inputs/OrderByClauseTypeTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\InputType;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Inputs\FileInputType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClause;
+use Mrap\GraphCool\Types\Inputs\ModelOrderByClause;
 use Mrap\GraphCool\Types\TypeLoader;
 
 class OrderByClauseTypeTest extends TestCase
@@ -17,7 +17,7 @@ class OrderByClauseTypeTest extends TestCase
     public function testConstructor(): void
     {
         require_once($this->dataPath().'/app/Models/DummyModel.php');
-        $input = new OrderByClause('_DummyModelOrderByClause', new TypeLoader());
+        $input = new ModelOrderByClause('_DummyModelOrderByClause', new TypeLoader());
         self::assertInstanceOf(InputType::class, $input);
     }
 }

--- a/tests/Types/TypeLoaderTest.php
+++ b/tests/Types/TypeLoaderTest.php
@@ -21,7 +21,7 @@ use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
 use Mrap\GraphCool\Types\Inputs\ModelInput;
-use Mrap\GraphCool\Types\Inputs\OrderByClause;
+use Mrap\GraphCool\Types\Inputs\ModelOrderByClause;
 use Mrap\GraphCool\Types\Inputs\WhereConditions;
 use Mrap\GraphCool\Types\Objects\ModelEdgePaginator;
 use Mrap\GraphCool\Types\Objects\ModelEdge;
@@ -178,7 +178,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModelOrderByClause')();
-        self::assertInstanceOf(OrderByClause::class, $result);
+        self::assertInstanceOf(ModelOrderByClause::class, $result);
     }
 
     public function testCreateEdgeReducedSelector(): void

--- a/tests/Types/TypeLoaderTest.php
+++ b/tests/Types/TypeLoaderTest.php
@@ -10,13 +10,13 @@ use Mrap\GraphCool\Definition\Field;
 use Mrap\GraphCool\Tests\TestCase;
 use Mrap\GraphCool\Types\Enums\ModelColumn;
 use Mrap\GraphCool\Types\Enums\DynamicEnumType;
-use Mrap\GraphCool\Types\Enums\EdgeColumnType;
+use Mrap\GraphCool\Types\Enums\EdgeColumn;
 use Mrap\GraphCool\Types\Enums\EdgeReducedColumnType;
 use Mrap\GraphCool\Types\Inputs\ModelColumnMapping;
-use Mrap\GraphCool\Types\Inputs\EdgeColumnMappingType;
+use Mrap\GraphCool\Types\Inputs\EdgeColumnMapping;
 use Mrap\GraphCool\Types\Inputs\ModelRelation;
 use Mrap\GraphCool\Types\Inputs\ModelManyRelation;
-use Mrap\GraphCool\Types\Inputs\EdgeOrderByClauseType;
+use Mrap\GraphCool\Types\Inputs\EdgeOrderByClause;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedColumnMappingType;
 use Mrap\GraphCool\Types\Inputs\EdgeReducedSelectorType;
 use Mrap\GraphCool\Types\Inputs\EdgeSelectorType;
@@ -150,7 +150,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModel__belongs_to_manyEdgeOrderByClause')();
-        self::assertInstanceOf(EdgeOrderByClauseType::class, $result);
+        self::assertInstanceOf(EdgeOrderByClause::class, $result);
     }
 
     public function testCreateEdgeReducedColumn(): void
@@ -164,7 +164,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModel__belongs_to_manyEdgeColumn')();
-        self::assertInstanceOf(EdgeColumnType::class, $result);
+        self::assertInstanceOf(EdgeColumn::class, $result);
     }
 
     public function testCreateWhereConditions(): void
@@ -206,7 +206,7 @@ class TypeLoaderTest extends TestCase
     {
         $typeLoader = new TypeLoader();
         $result = $typeLoader->load('_DummyModel__belongs_to_manyEdgeColumnMapping')();
-        self::assertInstanceOf(EdgeColumnMappingType::class, $result);
+        self::assertInstanceOf(EdgeColumnMapping::class, $result);
     }
 
     public function testCreateColumnMapping(): void


### PR DESCRIPTION
* renamed `EdgeColumnType` to `EdgeColumn` (and refactored)
* renamed `EdgeColumnMappingType` to `EdgeColumnMapping` (and refactored)
* renamed `ColumnMappingType` to `ModelColumnMapping`
* renamed `EdgeOrderByClauseType` to `EdgeOrderByClause` (and refactored)
* renamed `OrderByClauseType` to `ModelOrderByClause`
* changed constructors to accept the relation object instead of a string
* Type class now has static methods for `columnMapping` and `orderByClause` that work for both models/nodes and edges/relations
* instantations for above classes have been replaced with those static methods

Schema before/after has been diff-ed and shows no changes

Depends on https://github.com/mRaPGmbH/GraphCool/pull/24 - ready for review after that has been merged