### PR TITLE
feat: add deferred batching to relations

### DIFF
--- a/src/DataSource/DB.php
+++ b/src/DataSource/DB.php
@@ -6,6 +6,7 @@ namespace Mrap\GraphCool\DataSource;
 
 use Mrap\GraphCool\DataSource\Mysql\MysqlDataProvider;
 use Mrap\GraphCool\Definition\Job;
+use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Enums\Result;
 use Mrap\GraphCool\Utils\StopWatch;
 use Ramsey\Uuid\Uuid;
@@ -74,10 +75,10 @@ class DB
      * @param mixed[] $args
      * @return stdClass
      */
-    public static function findAll(?string $tenantId, string $name, array $args): stdClass
+    public static function findNodes(?string $tenantId, string $name, array $args): stdClass
     {
         StopWatch::start(__METHOD__);
-        $result = self::get()->findAll($tenantId, $name, $args);
+        $result = self::get()->findNodes($tenantId, $name, $args);
         StopWatch::stop(__METHOD__);
         return $result;
     }
@@ -89,13 +90,30 @@ class DB
      * @param mixed[] $args
      * @return stdClass
      */
-    public static function loadAll(?string $tenantId, array $ids): array
+    public static function loadNodes(?string $tenantId, array $ids): array
     {
         StopWatch::start(__METHOD__);
-        $result = self::get()->loadAll($tenantId, $ids);
+        $result = self::get()->loadNodes($tenantId, $ids);
         StopWatch::stop(__METHOD__);
         return $result;
     }
+
+    public static function findEdges(?string $tenantId, string $nodeId, Relation $relation, array $args): array|stdClass
+    {
+        StopWatch::start(__METHOD__);
+        $result = self::get()->findEdges($tenantId, $nodeId, $relation, $args);
+        StopWatch::stop(__METHOD__);
+        return $result;
+    }
+
+    public static function loadEdges(?string $tenantId, array $ids): array
+    {
+        StopWatch::start(__METHOD__);
+        $result = self::get()->loadEdges($tenantId, $ids);
+        StopWatch::stop(__METHOD__);
+        return $result;
+    }
+
 
 
     /**

--- a/src/DataSource/DataProvider.php
+++ b/src/DataSource/DataProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\DataSource;
 
 use Mrap\GraphCool\Definition\Job;
+use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Enums\Result;
 use stdClass;
 
@@ -20,7 +21,9 @@ interface DataProvider
      * @param string|null $resultType
      * @return mixed[]
      */
-    public function loadAll(?string $tenantId, array $ids, ?string $resultType = Result::DEFAULT): array;
+    public function loadNodes(?string $tenantId, array $ids, ?string $resultType = Result::DEFAULT): array;
+
+    public function loadEdges(?string $tenantId, array $ids): array;
 
     /**
      * @param string $tenantId
@@ -52,7 +55,9 @@ interface DataProvider
      * @param mixed[] $args
      * @return stdClass
      */
-    public function findAll(?string $tenantId, string $name, array $args): stdClass;
+    public function findNodes(?string $tenantId, string $name, array $args): stdClass;
+
+    public function findEdges(?string $tenantId, string $nodeId, Relation $relation, array $args): array|stdClass;
 
     public function delete(string $tenantId, string $name, string $id): ?stdClass;
 

--- a/src/DataSource/Mysql/MysqlDataProvider.php
+++ b/src/DataSource/Mysql/MysqlDataProvider.php
@@ -43,7 +43,7 @@ class MysqlDataProvider implements DataProvider
      * @return stdClass
      * @throws Error
      */
-    public function findAll(?string $tenantId, string $name, array $args): stdClass
+    public function findNodes(?string $tenantId, string $name, array $args): stdClass
     {
         $limit = $args['first'] ?? 10;
         $page = $args['page'] ?? 1;
@@ -96,10 +96,11 @@ class MysqlDataProvider implements DataProvider
 
         $result = new stdClass();
         $result->paginatorInfo = PaginatorInfo::create(count($ids), $page, $limit, $total);
-        $result->data = function() use($tenantId, $ids, $resultType) {return $this->loadAll($tenantId, $ids, $resultType);};
+        $result->data = function() use($tenantId, $ids, $resultType) {return $this->loadNodes($tenantId, $ids, $resultType);};
         $result->ids = $ids;
         return $result;
     }
+
 
     public function getMax(?string $tenantId, string $name, string $key): float|bool|int|string
     {
@@ -171,7 +172,7 @@ class MysqlDataProvider implements DataProvider
      * @param string|null $resultType
      * @return stdClass[]
      */
-    public function loadAll(?string $tenantId, array $ids, ?string $resultType = Result::DEFAULT): array {
+    public function loadNodes(?string $tenantId, array $ids, ?string $resultType = Result::DEFAULT): array {
         $results = Mysql::nodeReader()->loadMany($tenantId, $ids, $resultType);
         foreach ($results as $key => $result) {
             $results[$key] = $this->retrieveFiles($result);
@@ -576,7 +577,7 @@ class MysqlDataProvider implements DataProvider
     protected function getClosure(string $tenantId, string $name, array $ids, string $resultType)
     {
         return function () use ($tenantId, $ids, $resultType) {
-            return $this->loadAll($tenantId, $ids, $resultType);
+            return $this->loadNodes($tenantId, $ids, $resultType);
         };
     }
 
@@ -755,4 +756,13 @@ class MysqlDataProvider implements DataProvider
     }
 
 
+    public function loadEdges(?string $tenantId, array $ids): array
+    {
+        return Mysql::edgeReader()->loadEdges2($tenantId, $ids);
+    }
+
+    public function findEdges(?string $tenantId, string $nodeId, Relation $relation, array $args): array|stdClass
+    {
+        return Mysql::edgeReader()->findEdges($tenantId, $nodeId, $relation, $args);
+    }
 }

--- a/src/DataSource/Mysql/MysqlQueryBuilder.php
+++ b/src/DataSource/Mysql/MysqlQueryBuilder.php
@@ -43,19 +43,19 @@ class MysqlQueryBuilder
 
     /**
      * @param Relation $relation
-     * @param string[] $parentIds
+     * @param string[] $nodeIds
      * @return MysqlQueryBuilder
      */
-    public static function forRelation(Relation $relation, array $parentIds): MysqlQueryBuilder
+    public static function forRelation(Relation $relation, array $nodeIds): MysqlQueryBuilder
     {
         $builder = new MysqlQueryBuilder();
         $builder->name = 'edge';
         if ($relation->type === Relation::HAS_ONE || $relation->type === Relation::HAS_MANY) {
-            $builder->where[] = $builder->fieldName('_parent_id') . ' IN ' . $builder->parameterArray($parentIds);
+            $builder->where[] = $builder->fieldName('_parent_id') . ' IN ' . $builder->parameterArray($nodeIds);
             $builder->where[] = $builder->fieldName('_child') . ' = ' . $builder->parameter($relation->name);
             $builder->joins[] = 'LEFT JOIN `node` ON `node`.`id` = ' . $builder->fieldName('_child_id');
         } elseif ($relation->type === Relation::BELONGS_TO || $relation->type === Relation::BELONGS_TO_MANY) {
-            $builder->where[] = $builder->fieldName('_child_id') . ' IN ' . $builder->parameterArray($parentIds);
+            $builder->where[] = $builder->fieldName('_child_id') . ' IN ' . $builder->parameterArray($nodeIds);
             $builder->where[] = $builder->fieldName('_parent') . ' = ' . $builder->parameter($relation->name);
             $builder->joins[] = 'LEFT JOIN `node` ON `node`.`id` = ' . $builder->fieldName('_parent_id');
         } else {

--- a/src/Definition/NodeCaching.php
+++ b/src/Definition/NodeCaching.php
@@ -19,21 +19,28 @@ trait NodeCaching
     /** @var stdClass[] */
     private static array $loadedNodes = [];
 
-    protected function load(string $tenantId, string $name, string $id, ?string $resultType = Result::DEFAULT): Deferred
+    /** @var stdClass[] */
+    private static array $edgeIds = [];
+
+    /** @var stdClass[] */
+    private static array $loadedEdges = [];
+
+
+    protected function loadNodeDeferred(string $tenantId, string $name, string $id, ?string $resultType = Result::DEFAULT): Deferred
     {
         $this->checkTenantId($tenantId);
-        $this->addId($id);
+        $this->addNodeId($id);
         return new Deferred(function () use ($name, $id, $resultType) {
             $this->loadNodes();
             return $this->filterNode($id, $name, $resultType);
         });
     }
 
-    protected function loadAll(string $tenantId, string $name, array $ids, ?string $resultType = Result::DEFAULT): Deferred
+    protected function loadNodesDeferred(string $tenantId, string $name, array $ids, ?string $resultType = Result::DEFAULT): Deferred
     {
         $this->checkTenantId($tenantId);
         foreach ($ids as $id) {
-            $this->addId($id);
+            $this->addNodeId($id);
         }
         return new Deferred(function () use ($name, $ids, $resultType) {
             $this->loadNodes();
@@ -41,18 +48,67 @@ trait NodeCaching
         });
     }
 
-    protected function findAll(?string $tenantId, string $name, array $args): Deferred
+    protected function findNodesDeferred(?string $tenantId, string $name, array $args): Deferred
     {
         $this->checkTenantId($tenantId);
-        return new Deferred(function () use ($tenantId, $name, $args) {
-            return DB::findAll($tenantId, $name, $args);
+        $all = DB::findNodes($tenantId, $name, $args);
+        $resultType = $args['result'] ?? Result::DEFAULT;
+        foreach ($all->ids as $id) {
+            $this->addNodeId($id);
+        }
+        return new Deferred(function () use ($name, $all, $resultType) {
+            $this->loadNodes();
+            $ids = $all->ids;
+            $all->data = function() use ($name, $ids, $resultType) {
+                return $this->filterNodes($ids, $name, $resultType);
+            };
+            return $all;
         });
     }
 
-    private function addId(string $id): void
+    private function findEdgesDeferred(?string $tenantId, stdClass $modelData, Relation $relation, array $args): Deferred
+    {
+        $this->checkTenantId($tenantId, 'Edge');
+        $result = DB::findEdges($tenantId, $modelData->id, $relation, $args);
+        if (is_array($result)) {
+            $edgeIds = $result;
+        } else {
+            $edgeIds = $result->edges;
+        }
+        foreach ($edgeIds as $edgeId) {
+            $this->addEdgeId($edgeId);
+            $this->addNodeId($edgeId->parent_id);
+            $this->addNodeId($edgeId->child_id);
+        }
+        return new Deferred(function () use ($result, $edgeIds, $relation) {
+            $this->loadNodes();
+            $this->loadEdges();
+            if (is_array($result)) {
+                return $this->filterEdges($edgeIds, $relation)[0] ?? null;
+            }
+            $result->edges = $this->filterEdges($edgeIds, $relation);
+            return $result;
+        });
+    }
+
+
+    private function addNodeId(string $id): void
     {
         if (!array_key_exists($id, self::$loadedNodes)) {
             self::$nodeIds[$id] = $id;
+        }
+    }
+
+    private function combineEdgeId(stdClass $edge): string
+    {
+        return $edge->parent_id . '.' . $edge->child_id;
+    }
+
+    private function addEdgeId(stdClass $edgeId): void
+    {
+        $combined = $this->combineEdgeId($edgeId);
+        if (!array_key_exists($combined, self::$loadedEdges)) {
+            self::$edgeIds[$combined] = $edgeId;
         }
     }
 
@@ -61,7 +117,7 @@ trait NodeCaching
         if (count(static::$nodeIds) === 0) {
             return;
         }
-        static::$loadedNodes = array_merge(self::$loadedNodes, DB::loadAll(self::$tenantId, self::$nodeIds));
+        static::$loadedNodes = array_merge(self::$loadedNodes, DB::loadNodes(self::$tenantId, self::$nodeIds));
         static::$nodeIds = [];
     }
 
@@ -100,12 +156,39 @@ trait NodeCaching
         return true;
     }
 
-    private function checkTenantId(string $tenantId): void
+    private function checkTenantId(string $tenantId, string $errorText = 'Node'): void
     {
-        if (static::$tenantId !== null && static::$tenantId !== $tenantId) {
-            throw new RuntimeException('Cannot change TenantId when using NodeCaching: ' . static::$tenantId . ' => ' . $tenantId);
+        if (self::$tenantId !== null && static::$tenantId !== $tenantId) {
+            throw new RuntimeException('Cannot change TenantId when using ' . $errorText . 'Caching: ' . static::$tenantId . ' => ' . $tenantId);
         }
-        static::$tenantId = $tenantId;
+        self::$tenantId = $tenantId;
+    }
+
+    private function loadEdges(): void
+    {
+        if (count(static::$edgeIds) === 0) {
+            return;
+        }
+        static::$loadedEdges = array_merge(self::$loadedEdges, DB::loadEdges(self::$tenantId, self::$edgeIds));
+        static::$edgeIds = [];
+    }
+
+    private function filterEdges(array $edgeIds, Relation $relation): array
+    {
+        $result = [];
+        foreach ($edgeIds as $edgeId) {
+            $combined = $this->combineEdgeId($edgeId);
+            $edge = self::$loadedEdges[$combined] ?? null;
+            if ($edge !== null) {
+                $edgeClone = clone $edge;
+                $edgeClone->_node = match($relation->type) {
+                    Relation::BELONGS_TO, Relation::BELONGS_TO_MANY => $this->filterNode($edge->parent_id, $edge->parent),
+                    Relation::HAS_ONE, Relation::HAS_MANY => $this->filterNode($edge->child_id, $edge->child),
+                };
+                $result[] = $edgeClone;
+            }
+        }
+        return $result;
     }
 
 

--- a/src/Queries/ExportModel.php
+++ b/src/Queries/ExportModel.php
@@ -43,7 +43,7 @@ class ExportModel extends Query
         $type = $args['type'] ?? 'xlsx';
         $args['first'] = 1048575; // max number of rows allowed in excel - 1 (for headers)
 
-        $data = DB::findAll(JwtAuthentication::tenantId(), $this->model, $args)->data;
+        $data = DB::findNodes(JwtAuthentication::tenantId(), $this->model, $args)->data;
         if ($data instanceof \Closure) {
             $data = $data();
         }

--- a/src/Queries/ListModel.php
+++ b/src/Queries/ListModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Queries;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use Mrap\GraphCool\DataSource\DB;
 use Mrap\GraphCool\Definition\ModelBased;
 use Mrap\GraphCool\Definition\NodeCaching;
 use Mrap\GraphCool\Definition\Query;
@@ -59,7 +58,6 @@ class ListModel extends Query
     public function resolve(array $rootValue, array $args, mixed $context, ResolveInfo $info): mixed
     {
         Authorization::authorize('find', $this->model);
-        return DB::findAll(JwtAuthentication::tenantId(), $this->model , $args);
-        //return $this->findAll(JwtAuthentication::tenantId(), $this->model , $args);
+        return $this->findNodesDeferred(JwtAuthentication::tenantId(), $this->model , $args);
     }
 }

--- a/src/Queries/ReadModel.php
+++ b/src/Queries/ReadModel.php
@@ -39,7 +39,6 @@ class ReadModel extends Query
     public function resolve(array $rootValue, array $args, mixed $context, ResolveInfo $info): mixed
     {
         Authorization::authorize('read', $this->model);
-        //return DB::load(JwtAuthentication::tenantId(), $this->model, $args['id']);
-        return $this->load(JwtAuthentication::tenantId(), $this->model, $args['id']);
+        return $this->loadNodeDeferred(JwtAuthentication::tenantId(), $this->model, $args['id']);
     }
 }

--- a/src/Types/Objects/ModelObject.php
+++ b/src/Types/Objects/ModelObject.php
@@ -7,9 +7,12 @@ namespace Mrap\GraphCool\Types\Objects;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\Definition\Model;
+use Mrap\GraphCool\Definition\NodeCaching;
 use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\DynamicTypeTrait;
 use Mrap\GraphCool\Types\Type;
+use Mrap\GraphCool\Utils\JwtAuthentication;
+use Mrap\GraphCool\Utils\StopWatch;
 use stdClass;
 use function Mrap\GraphCool\model;
 
@@ -17,6 +20,7 @@ class ModelObject extends ObjectType
 {
 
     use DynamicTypeTrait;
+    use NodeCaching;
 
     protected Model $model;
 
@@ -86,8 +90,11 @@ class ModelObject extends ObjectType
     {
         $field = $this->model->{$info->fieldName} ?? null;
         if ($field instanceof Relation) {
-            $closure = $modelData->{$info->fieldName};
-            return $closure($args);
+            StopWatch::start('RESOLVE RELATION');
+            StopWatch::stop('RESOLVE RELATION');
+            return $this->findEdgesDeferred(JwtAuthentication::tenantId(), $modelData, $field, $args);
+            //$closure = $modelData->{$info->fieldName};
+            //return $closure($args);
         }
         return $modelData->{$info->fieldName} ?? null;
     }

--- a/src/Utils/Exporter.php
+++ b/src/Utils/Exporter.php
@@ -21,7 +21,7 @@ class Exporter
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $jwt;
 
-        $data = DB::findAll($job->tenantId, $name, $args)->data;
+        $data = DB::findNodes($job->tenantId, $name, $args)->data;
         if ($data instanceof Closure) {
             $data = $data();
         }

--- a/tests/DataSource/DBTest.php
+++ b/tests/DataSource/DBTest.php
@@ -42,7 +42,7 @@ class DBTest extends TestCase
             ->with('a','b',['c'])
             ->willReturn($expected);
         DB::setProvider($mock);
-        $result = DB::findAll('a','b',['c']);
+        $result = DB::findNodes('a','b',['c']);
         self::assertSame($expected, $result);
     }
 

--- a/tests/DataSource/Mysql/MysqlDataProviderTest.php
+++ b/tests/DataSource/Mysql/MysqlDataProviderTest.php
@@ -26,7 +26,7 @@ class MysqlDataProviderTest extends TestCase
         require_once($this->dataPath().'/app/Models/DummyModel.php');
         $this->expectException(Error::class);
         $provider = new MysqlDataProvider();
-        $provider->findAll('a12f', 'DummyModel', ['page' => 0]);
+        $provider->findNodes('a12f', 'DummyModel', ['page' => 0]);
     }
 
     public function testFindAll(): void
@@ -74,7 +74,7 @@ class MysqlDataProviderTest extends TestCase
             'total' => 1
         ];
         foreach ([Result::DEFAULT, Result::WITH_TRASHED, Result::ONLY_SOFT_DELETED] as $resultType) {
-            $result = $provider->findAll('a12f', 'DummyModel', ['where' => ['column' => 'last_name', 'operator' => '=', 'value' => 'b'], 'result' => $resultType]);
+            $result = $provider->findNodes('a12f', 'DummyModel', ['where' => ['column' => 'last_name', 'operator' => '=', 'value' => 'b'], 'result' => $resultType]);
             self::assertEquals($expected, $result->paginatorInfo, 'Pagination Info does not match expectation for ' . $resultType);
             self::assertEquals([$node], ($result->data)(), 'Data does not match expectation for ' . $resultType);
         }
@@ -761,7 +761,7 @@ class MysqlDataProviderTest extends TestCase
         File::setFileProvider($mock);
 
         $provider = new MysqlDataProvider();
-        $result = $provider->load('a12f', 'DummyModel', 'y5');
+        $result = $provider->load('a12f', 'y5');
 
         self::assertSame('SGVsbG8gV29ybGQh', $result->file->data_base64);
         self::assertSame('test.txt', $result->file->filename);


### PR DESCRIPTION
It finally works! A bit of cleanup is still needed - but that will follow in the next PR, as this one already is more than 200 added lines.

* loading of edges (previusly done in `MysqlEdgeReader::findRelatedNodes()`) has now been split into parts:
* `MysqlEdgeReader::findEdges()` applies the WHEREs and returns all matching id-pairs (parent-id, child-id)
* `MysqlEdgeReader::loadEdges2()` then hydrates those id-pairs, by enriching them with properties and the related nodes
* the first part - findEdges - happens once for each relation queried - but the second part batches both the property and the node loading
* maybe this could be further optimized, to batch some of the findEdge stuff as well?
* the `NodeCaching` trait has been extendend with edge caching capabilities (similar to how nodeCaching works)
* the `resolve()` function of the ModelObject now uses the `NodeCaching` trait, instead of the closure in the loaded node
* mutation resolvers have not been switched to the `NodeCaching` trait yet - will follow in next PR

As usual the GraphQL Schema has been confirmed to be free of changes, and a test-suite of typical queries and mutations has been used to test for errors.