### PR TITLE
refactor: cleanup after deferred batching implementation

### DIFF
--- a/src/DataSource/DB.php
+++ b/src/DataSource/DB.php
@@ -106,10 +106,10 @@ class DB
         return $result;
     }
 
-    public static function loadEdges(?string $tenantId, array $ids): array
+    public static function loadEdges(array $ids): array
     {
         StopWatch::start(__METHOD__);
-        $result = self::get()->loadEdges($tenantId, $ids);
+        $result = self::get()->loadEdges($ids);
         StopWatch::stop(__METHOD__);
         return $result;
     }

--- a/src/DataSource/DataProvider.php
+++ b/src/DataSource/DataProvider.php
@@ -23,7 +23,7 @@ interface DataProvider
      */
     public function loadNodes(?string $tenantId, array $ids, ?string $resultType = Result::DEFAULT): array;
 
-    public function loadEdges(?string $tenantId, array $ids): array;
+    public function loadEdges(array $ids): array;
 
     /**
      * @param string $tenantId

--- a/src/DataSource/Mysql/MysqlDataProvider.php
+++ b/src/DataSource/Mysql/MysqlDataProvider.php
@@ -351,17 +351,6 @@ class MysqlDataProvider implements DataProvider
         return Mysql::increment($tenantId, $key, $min, $transaction);
     }
 
-    protected function checkIfNodeExists(string $tenantId, Model $model, string $name, string $id): void
-    {
-        $query = MysqlQueryBuilder::forModel($model, $name)
-            ->tenant($tenantId)
-            ->where(['column' => 'id', 'operator' => '=', 'value' => $id])
-            ->withTrashed();
-        if ((int)Mysql::fetchColumn($query->toCountSql(), $query->getParameters()) === 0) {
-            throw new Error($name . ' with ID ' . $id . ' not found.');
-        }
-    }
-
     /**
      * @throws JsonException
      */
@@ -756,9 +745,9 @@ class MysqlDataProvider implements DataProvider
     }
 
 
-    public function loadEdges(?string $tenantId, array $ids): array
+    public function loadEdges(array $ids): array
     {
-        return Mysql::edgeReader()->loadEdges2($tenantId, $ids);
+        return Mysql::edgeReader()->loadEdges($ids);
     }
 
     public function findEdges(?string $tenantId, string $nodeId, Relation $relation, array $args): array|stdClass

--- a/src/DataSource/Mysql/MysqlDataProvider.php
+++ b/src/DataSource/Mysql/MysqlDataProvider.php
@@ -168,6 +168,7 @@ class MysqlDataProvider implements DataProvider
 
 
     /**
+     * @param string|null $tenantId
      * @param string[] $ids
      * @param string|null $resultType
      * @return stdClass[]
@@ -258,7 +259,6 @@ class MysqlDataProvider implements DataProvider
 
             Mysql::nodeWriter()->update($tenantId, $name, $data['id'], $updates);
 
-            Mysql::reset(true);
             $loaded = $this->load($tenantId, $data['id'], Result::WITH_TRASHED);
             if ($loaded !== null) {
                 $model->afterUpdate($loaded);

--- a/src/DataSource/Mysql/MysqlNodeReader.php
+++ b/src/DataSource/Mysql/MysqlNodeReader.php
@@ -34,7 +34,7 @@ class MysqlNodeReader
         }
         $nodes = [];
         foreach ($this->fetchNodes($tenantId, $ids, $resultType) as $id => $node) {
-            $nodes[$id] = Mysql::edgeReader()->loadEdges($node, $node->model);
+            $nodes[$id] = Mysql::edgeReader()->injectEdgeClosures($node);
         }
         if (count($nodes) === 0) {
             StopWatch::stop(__METHOD__);
@@ -72,7 +72,7 @@ class MysqlNodeReader
                     $node->$date = $dateTime->getPreciseTimestamp(3);
                 }
             }
-            $nodes[$node->id] = Mysql::edgeReader()->loadEdges($node, 'sdf');
+            $nodes[$node->id] = Mysql::edgeReader()->injectEdgeClosures($node);
         }
         StopWatch::stop(__METHOD__);
         return Sorter::sortNodesByIdOrder($nodes, $ids);

--- a/src/DataSource/Mysql/MysqlQueryBuilder.php
+++ b/src/DataSource/Mysql/MysqlQueryBuilder.php
@@ -6,10 +6,8 @@ namespace Mrap\GraphCool\DataSource\Mysql;
 
 use GraphQL\Error\Error;
 use Mrap\GraphCool\DataSource\FullTextIndex;
-use Mrap\GraphCool\Definition\Field;
 use Mrap\GraphCool\Definition\Model;
 use Mrap\GraphCool\Definition\Relation;
-use Mrap\GraphCool\Types\Type;
 use Ramsey\Uuid\Uuid;
 use RuntimeException;
 

--- a/src/Mutations/CreateModel.php
+++ b/src/Mutations/CreateModel.php
@@ -38,7 +38,7 @@ class CreateModel extends Mutation
         foreach ($modelObj->relations() as $key => $relation) {
             $relationType = Type::relation($relation);
             if ($relationType !== null) {
-                if ($relation->null === false || $relation->type === Relation::BELONGS_TO_MANY) {
+                if ($relation->null === false || $relation->type === Relation::BELONGS_TO_MANY) { // TODO: should this be BELONGS_TO ?
                     $relationType = Type::nonNull($relationType);
                 }
                 if ($relation->type === Relation::BELONGS_TO_MANY) {
@@ -46,19 +46,6 @@ class CreateModel extends Mutation
                 }
                 $args[$key] = $relationType;
             }
-
-            /*
-            if ($relation->type === Relation::BELONGS_TO) {
-                if ($relation->null) {
-                    $args[$key] = Type::get('_' . $model . '__' . $key . 'Relation');
-                } else {
-                    $args[$key] = Type::nonNull(Type::get('_' . $model . '__' . $key . 'Relation'));
-                }
-            } elseif ($relation->type === Relation::BELONGS_TO_MANY) {
-                $args[$key] = Type::listOf(
-                    Type::nonNull(Type::get('_' . $model . '__' . $key . 'ManyRelation'))
-                );
-            }*/
         }
         $args['_timezone'] = Type::timezoneOffset();
         ksort($args);

--- a/src/Queries/ListModel.php
+++ b/src/Queries/ListModel.php
@@ -6,7 +6,7 @@ namespace Mrap\GraphCool\Queries;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\Definition\ModelBased;
-use Mrap\GraphCool\Definition\NodeCaching;
+use Mrap\GraphCool\Definition\DeferredBatching;
 use Mrap\GraphCool\Definition\Query;
 use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\Type;
@@ -19,7 +19,7 @@ use function Mrap\GraphCool\model;
 class ListModel extends Query
 {
     use ModelBased;
-    use NodeCaching;
+    use DeferredBatching;
 
     public function __construct(?string $model = null)
     {

--- a/src/Queries/ReadModel.php
+++ b/src/Queries/ReadModel.php
@@ -6,7 +6,7 @@ namespace Mrap\GraphCool\Queries;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\Definition\ModelBased;
-use Mrap\GraphCool\Definition\NodeCaching;
+use Mrap\GraphCool\Definition\DeferredBatching;
 use Mrap\GraphCool\Definition\Query;
 use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Utils\Authorization;
@@ -16,7 +16,7 @@ use RuntimeException;
 class ReadModel extends Query
 {
     use ModelBased;
-    use NodeCaching;
+    use DeferredBatching;
 
     public function __construct(?string $model = null)
     {

--- a/src/Types/Objects/ModelObject.php
+++ b/src/Types/Objects/ModelObject.php
@@ -7,12 +7,11 @@ namespace Mrap\GraphCool\Types\Objects;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\Definition\Model;
-use Mrap\GraphCool\Definition\NodeCaching;
+use Mrap\GraphCool\Definition\DeferredBatching;
 use Mrap\GraphCool\Definition\Relation;
 use Mrap\GraphCool\Types\DynamicTypeTrait;
 use Mrap\GraphCool\Types\Type;
 use Mrap\GraphCool\Utils\JwtAuthentication;
-use Mrap\GraphCool\Utils\StopWatch;
 use stdClass;
 use function Mrap\GraphCool\model;
 
@@ -20,7 +19,7 @@ class ModelObject extends ObjectType
 {
 
     use DynamicTypeTrait;
-    use NodeCaching;
+    use DeferredBatching;
 
     protected Model $model;
 
@@ -90,11 +89,7 @@ class ModelObject extends ObjectType
     {
         $field = $this->model->{$info->fieldName} ?? null;
         if ($field instanceof Relation) {
-            StopWatch::start('RESOLVE RELATION');
-            StopWatch::stop('RESOLVE RELATION');
             return $this->findEdgesDeferred(JwtAuthentication::tenantId(), $modelData, $field, $args);
-            //$closure = $modelData->{$info->fieldName};
-            //return $closure($args);
         }
         return $modelData->{$info->fieldName} ?? null;
     }

--- a/tests/DataSource/Mysql/MysqlEdgeReaderTest.php
+++ b/tests/DataSource/Mysql/MysqlEdgeReaderTest.php
@@ -24,7 +24,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $result = $reader->loadEdges($node, 'DummyModel');
+        $result = $reader->injectEdgeClosures($node);
 
         self::assertInstanceOf(Closure::class, $result->belongs_to);
         self::assertInstanceOf(Closure::class, $result->belongs_to2);
@@ -84,7 +84,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to;
 
         $args = [];
@@ -101,7 +101,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to;
 
         $args = ['page' => 0];
@@ -154,7 +154,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to;
 
         $args['result'] = Result::ONLY_SOFT_DELETED;
@@ -209,7 +209,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to;
 
         $args['result'] = Result::WITH_TRASHED;
@@ -264,7 +264,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to;
 
         $args['result'] = 'NONTRASHED_EDGES_OF_ANY_NODES';
@@ -319,7 +319,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->belongs_to_many;
 
         $args = [];
@@ -387,7 +387,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->has_one;
 
         $args = [];
@@ -442,7 +442,7 @@ class MysqlEdgeReaderTest extends TestCase
         $node->id = 'asdf123123';
         $node->tenant_id = 'hc123';
 
-        $node = $reader->loadEdges($node, 'DummyModel');
+        $node = $reader->injectEdgeClosures($node);
         $closure = $node->has_one;
 
         $args = [];


### PR DESCRIPTION
Some cleanup, renaming and removal of unused code and unused params, after the deferred batching implementation.

* Edge closures cannot be removed yet - are still being used directly in some custom CRM endpoints.
* mutations cannot use caching for the inserts/update part
* load part of mutations already uses deferred batching for relations/edges (through ModelObject)
* import/export can't use deferred batching, as the data isn't being loaded through graphql-php
