### PR TITLE
fix: increase group concat max length

### DIFF
--- a/src/DataSource/Mysql/MysqlFullTextIndexProvider.php
+++ b/src/DataSource/Mysql/MysqlFullTextIndexProvider.php
@@ -33,10 +33,13 @@ class MysqlFullTextIndexProvider implements FullTextIndexProvider
 
     public function shutdown(): void
     {
-        foreach ($this->needIndexing as $tenantId => $models) {
-            $this->updateIndex((string)$tenantId, $models);
+        if (count($this->needIndexing) > 0) {
+            Mysql::getPdo()->exec('SET SESSION group_concat_max_len =  4294967295');
+            foreach ($this->needIndexing as $tenantId => $models) {
+                $this->updateIndex((string)$tenantId, $models);
+            }
+            $this->needIndexing = [];
         }
-        $this->needIndexing = [];
         if (count($this->needDeletion) > 0) {
             $sql = 'DELETE FROM `fulltext` WHERE `node_id` IN '. $this->quoteArray($this->needDeletion);
             Mysql::getPdo()->exec($sql);

--- a/src/DataSource/Mysql/MysqlFullTextIndexProvider.php
+++ b/src/DataSource/Mysql/MysqlFullTextIndexProvider.php
@@ -34,7 +34,7 @@ class MysqlFullTextIndexProvider implements FullTextIndexProvider
     public function shutdown(): void
     {
         if (count($this->needIndexing) > 0) {
-            Mysql::getPdo()->exec('SET SESSION group_concat_max_len =  4294967295');
+            Mysql::getPdo()->exec('SET SESSION group_concat_max_len = 4294967295');
             foreach ($this->needIndexing as $tenantId => $models) {
                 $this->updateIndex((string)$tenantId, $models);
             }


### PR DESCRIPTION
Hotfix - will be merged into main.

`group_concat_max_len` is set to 1024 by default - this can cause the data for the fulltext search cache to be truncated, if the customer comment is long.

to fix this, we set the `group_concat_max_len` to the highest possible 32bit value.