### PR TITLE
feat: improved export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.3",
     "webonyx/graphql-php": "^14.4",
     "ext-json": "^8.0",
     "vlucas/phpdotenv": "^5.2",

--- a/src/DataSource/File.php
+++ b/src/DataSource/File.php
@@ -27,9 +27,9 @@ class File
      * @throws \Box\Spout\Common\Exception\IOException
      * @throws \Box\Spout\Writer\Exception\WriterNotOpenedException
      */
-    public static function write(string $name, array $data, array $args, string $type = 'xlsx'): stdClass
+    public static function write(string $name, array $data, array $args, string $type = 'xlsx', string $postFix = ''): stdClass
     {
-        return self::getExporter()->export($name, $data, $args, $type);
+        return self::getExporter()->export($name, $data, $args, $type, $postFix);
     }
 
     /**

--- a/src/Exception/OutOfMemoryException.php
+++ b/src/Exception/OutOfMemoryException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mrap\GraphCool\Exception;
+
+use RuntimeException;
+
+class OutOfMemoryException extends RuntimeException
+{
+
+}

--- a/src/Queries/ExportModel.php
+++ b/src/Queries/ExportModel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mrap\GraphCool\Queries;
 
-use Closure;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use Mrap\GraphCool\DataSource\File;
@@ -15,7 +14,6 @@ use Mrap\GraphCool\Utils\Authorization;
 use Mrap\GraphCool\Utils\Exporter;
 use Mrap\GraphCool\Utils\JwtAuthentication;
 use RuntimeException;
-use stdClass;
 
 use function Mrap\GraphCool\pluralize;
 

--- a/src/Utils/Exporter.php
+++ b/src/Utils/Exporter.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Mrap\GraphCool\Utils;
 
 use Closure;
+use GraphQL\Error\Error;
 use Mrap\GraphCool\DataSource\DB;
 use Mrap\GraphCool\DataSource\File;
 use Mrap\GraphCool\Definition\Job;
+use Mrap\GraphCool\Exception\OutOfMemoryException;
+use stdClass;
 
 class Exporter
 {
@@ -16,23 +19,40 @@ class Exporter
     {
         $name = $job->data['name'];
         $args = $job->data['args'];
+        $startAt = $job->data['startAt'] ?? 1;
+        $num = $job->data['num'] ?? 1;
         $jwt = $job->data['jwt'];
-        $type = $args['type'] ?? 'csv';
-
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $jwt;
+        $type = $args['type'] ?? 'csv';
+        $postFix = '';
 
-        $data = DB::findNodes($job->tenantId, $name, $args)->data;
-        if ($data instanceof Closure) {
-            $data = $data();
+        $data = $this->loadData($job->tenantId, $name, $args, $startAt, false);
+
+        $closure = function() {};
+
+        if ($startAt !== null) {
+            $postFix = '_Part-' . $num;
+            $jobData = $job->data;
+            $jobData['startAt'] = $startAt;
+            $jobData['num'] = $num + 1;
+            $closure = function() use($job, $name, $jobData) {
+                DB::addJob($job->tenantId, $job->worker, $name, $jobData);
+            };
+        } elseif ($num > 1) {
+            $postFix = '_Part-' . $num;
         }
 
         $file = File::write(
             $name,
             $data ?? [],
             $args,
-            $type
+            $type,
+            $postFix
         );
         $data = File::store($name, 'export', $type , get_object_vars($file));
+
+        $closure(); // only insert new job, after we are sure the current job is a success
+
         return [
             'success' => true,
             'filename' => $data->filename,
@@ -41,4 +61,60 @@ class Exporter
             'filesize' => $data->filesize
         ];
     }
+
+    public function loadData(string $tenantId, string $name, array $args, ?int &$startAt = 1, bool $throwError = true): array
+    {
+        memory_reset_peak_usage();
+        $data = [];
+        $unsets = null;
+        $args['first'] = 100;
+        $pages = DB::findNodes(JwtAuthentication::tenantId(), $name, $args)->paginatorInfo->lastPage;
+
+        try {
+            for ($page = $startAt; $page <= $pages; $page++) {
+                $startAt = null;
+                $args['page'] = $page;
+
+                $rows = DB::findNodes($tenantId, $name, $args)->data;
+                if ($rows instanceof Closure) {
+                    $rows = $rows();
+                }
+                if (memory_get_peak_usage() > 104857600) { // 100 MB
+                    $startAt = $page;
+                    throw new OutOfMemoryException();
+                }
+                foreach ($rows as $row) {
+                    if ($unsets === null) {
+                        $unsets = $this->getUnsets($row, $args);
+                    }
+                    foreach ($unsets as $unset) {
+                        unset($row->$unset);
+                    }
+                    $data[] = $row;
+                }
+                if (memory_get_peak_usage() > 104857600) { // 100 MB
+                    $startAt = $page+1;
+                    throw new OutOfMemoryException();
+                }
+            }
+        } catch (OutOfMemoryException) {
+            if ($throwError) {
+                throw new Error('Export too big - out of memory');
+            }
+        }
+        return $data;
+    }
+
+    protected function getUnsets(stdClass $row, array $args): array
+    {
+        $unsets = [];
+        foreach ($row as $key => $v) {
+            if ($v instanceof Closure && !isset($args[$key])) {
+                $unsets[] = $key;
+            }
+        }
+        return $unsets;
+    }
+
+
 }

--- a/src/Utils/Scheduler.php
+++ b/src/Utils/Scheduler.php
@@ -21,20 +21,15 @@ class Scheduler
         if (isset($this->config['always']) && !is_array($this->config['always'])) {
             throw new RuntimeException('Error in ' . ClassFinder::rootPath() . '/config/scheduler.php' . ': [\'always\'] is not an array.');
         }
-        if (isset($this->config['hourly']) && !is_array($this->config['hourly'])) {
-            throw new RuntimeException('Error in ' . ClassFinder::rootPath() . '/config/scheduler.php' . ': [\'hourly\'] is not an array.');
-        }
-        if (isset($this->config['daily']) && !is_array($this->config['daily'])) {
-            throw new RuntimeException('Error in ' . ClassFinder::rootPath() . '/config/scheduler.php' . ': [\'daily\'] is not an array.');
-        }
-        if (isset($this->config['weekly']) && !is_array($this->config['weekly'])) {
-            throw new RuntimeException('Error in ' . ClassFinder::rootPath() . '/config/scheduler.php' . ': [\'weekly\'] is not an array.');
+        if (isset($this->config['each-start']) && !is_array($this->config['each-start'])) {
+            throw new RuntimeException('Error in ' . ClassFinder::rootPath() . '/config/scheduler.php' . ': [\'each-start\'] is not an array.');
         }
     }
 
     public function run(): array
     {
         $this->start = time();
+        $this->runScripts($this->config['each-start'] ?? []);
         while ($this->time() < 290) {
             set_time_limit(90);
             $this->loop();
@@ -59,7 +54,6 @@ class Scheduler
             return;
             // @codeCoverageIgnoreEnd
         }
-        // TODO: hourly, daily, weekly?
         while (time() - $start < 15) {
             if ($this->runJob() === false) {
                 break;

--- a/src/Utils/StopWatch.php
+++ b/src/Utils/StopWatch.php
@@ -98,4 +98,9 @@ class StopWatch
         Mysql::execute($sql, $params);
     }
 
+    public static function currentRunTime(): float
+    {
+        return microtime(true) - self::$firstStart ?? 0.0;
+    }
+
 }


### PR DESCRIPTION
file export (sowohl sync direkt via graphql-call als auch async via background worker und job) arbeitet nun wie folgt:

* in batches zu je 100 rows
* mit unset unused closures pro row für weniger RAM bedarf
* mit memory-check während jedem batch
* sync out-of-memory beendet sich mit graphql client-safe error
* async out-of-memory splittet das file in mehrere parts, speichert den aktuellen part, und erstellt einen neuen job für den nächsten part
