### PR TITLE
feat: support webonyx/graphql-php 15 + scalars 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
   },
   "require": {
     "php": ">=8.3",
-    "webonyx/graphql-php": "^14.4",
+    "webonyx/graphql-php": "^15.0",
     "ext-json": "^8.0",
     "vlucas/phpdotenv": "^5.2",
     "ext-pdo": "^8.0",
     "ramsey/uuid": "^4.1",
     "box/spout": "^3.1",
-    "mll-lab/graphql-php-scalars": "^4.0",
+    "mll-lab/graphql-php-scalars": "^6.0",
     "nesbot/carbon": "^2.46",
     "lcobucci/jwt": "^4.1"
   },

--- a/src/Types/Scalars/Date.php
+++ b/src/Types/Scalars/Date.php
@@ -22,8 +22,8 @@ class Date extends ScalarType
         return '_Date';
     }
 
-    public $name = '_Date';
-    public $description = 'A Date string in ISO 8601 format: "2021-03-11"';
+    public string $name = '_Date';
+    public ?string $description = 'A Date string in ISO 8601 format: "2021-03-11"';
 
     public function serialize(mixed $value): string
     {

--- a/src/Types/Scalars/DateTime.php
+++ b/src/Types/Scalars/DateTime.php
@@ -23,8 +23,8 @@ class DateTime extends ScalarType
         return '_DateTime';
     }
 
-    public $name = '_DateTime';
-    public $description = 'A DateTime string with timezone in following ISO 8601 format: "2021-03-11T11:54:04.123+00:00". When used as input several other ISO 8601 variants are accepted as well.';
+    public string $name = '_DateTime';
+    public ?string $description = 'A DateTime string with timezone in following ISO 8601 format: "2021-03-11T11:54:04.123+00:00". When used as input several other ISO 8601 variants are accepted as well.';
 
     public function serialize(mixed $value): string
     {

--- a/src/Types/Scalars/Time.php
+++ b/src/Types/Scalars/Time.php
@@ -23,8 +23,8 @@ class Time extends ScalarType
         return '_Time';
     }
 
-    public $name = '_Time';
-    public $description = 'A Time string in ISO 8601 format: "11:54:04+00:00" or "11:54:04Z"';
+    public string $name = '_Time';
+    public ?string $description = 'A Time string in ISO 8601 format: "11:54:04+00:00" or "11:54:04Z"';
 
     public static function getObject(mixed $value): Carbon
     {

--- a/src/Types/Scalars/TimezoneOffset.php
+++ b/src/Types/Scalars/TimezoneOffset.php
@@ -23,8 +23,8 @@ class TimezoneOffset extends ScalarType
         return '_TimezoneOffset';
     }
 
-    public $name = '_TimezoneOffset';
-    public $description = 'A Timezone offset string in ISO 8601 format: "+00:00" or "Z"';
+    public string $name = '_TimezoneOffset';
+    public ?string $description = 'A Timezone offset string in ISO 8601 format: "+00:00" or "Z"';
 
     public function serialize(mixed $value): string
     {

--- a/src/Types/Scalars/Upload.php
+++ b/src/Types/Scalars/Upload.php
@@ -19,8 +19,8 @@ class Upload extends ScalarType
         return '_Upload';
     }
 
-    public $name = '_Upload';
-    public $description = 'A file to be uploaded (as multipart/blob).';
+    public string $name = '_Upload';
+    public ?string $description = 'A file to be uploaded (as multipart/blob).';
 
     public function serialize(mixed $value): void
     {

--- a/tests/Types/QueryTypeTest.php
+++ b/tests/Types/QueryTypeTest.php
@@ -163,6 +163,7 @@ ENUM pivot_enum!';
         $query->config['fields'](); // has to be called to prime setup
         $closure = $query->resolveFieldFn;
         $info = $this->createMock(ResolveInfo::class);
+        $info->fieldName = '';
         $info->returnType = $this->createMock(Type::class);
         $info->returnType->name = '_Import_JobPaginator';
 


### PR DESCRIPTION
## What

Upgrade graphcool to support **webonyx/graphql-php ^15** (was `^14.4`) and **mll-lab/graphql-php-scalars ^6.0** (was `^4.0`).

## Why

Downstream services (e.g. `myhello.cloud/file`) cannot clear `roave/security-advisories` — it forbids `webonyx/graphql-php <=15.32.2` (the "Inefficient Algorithmic Complexity" advisory covers all 14.x). graphcool's `^14.4` pin was the structural blocker. Bumping here unblocks consumers to resolve graphql-php ≥15.32.3 (15.33.1).

## Changes

- `composer.json`: `webonyx/graphql-php ^14.4 → ^15.0`, `mll-lab/graphql-php-scalars ^4.0 → ^6.0`.
- **5 custom Scalar types** (`Date`, `DateTime`, `Time`, `TimezoneOffset`, `Upload`): type `$name`/`$description` as `public string $name` / `public ?string $description`. Required because v15's `NamedTypeImplementation` trait declares these typed — untyped redeclarations now fatal at class-load. Values/descriptions unchanged.
- **1 test** (`QueryTypeTest::testResolveJobPaginator`): initialize the mocked `ResolveInfo::$fieldName` (now a non-nullable typed property in v15). Production is unaffected — the executor always sets `fieldName`.

## Behavioural note (v15)

graphql-php 15 no longer auto-injects `extensions.category` on errors. graphcool's auth errors still carry `category` (set manually via the `Error` constructor in `JwtAuthentication`), but other error paths (validation/syntax) will no longer include it. Consumers parsing `extensions.category` on non-auth errors should be aware.

## Verification

- Full PHPUnit suite **green: 442 tests, 21483 assertions** on PHP 8.3 under graphql-php 15.33.1 (only pre-existing `ClassFinderTest` env artifact remains, unrelated).
- Autoload smoke: all 5 scalars + `MixedScalar` construct under v15.
- Snyk code scan on changed files: 0 issues. `composer update`: no security advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)