### PR TITLE
feat: add Type::register for app-defined custom types

### DIFF
--- a/src/Types/Type.php
+++ b/src/Types/Type.php
@@ -76,6 +76,17 @@ abstract class Type extends BaseType implements NullableType
         return static::$types[$name];
     }
 
+    /**
+     * Register an application-defined type under a custom name so it can be
+     * resolved by get() / the schema type loader. Lets app code expose its own
+     * object/scalar types (e.g. a bespoke query result) that are not derived
+     * from a model.
+     */
+    public static function register(string $name, NullableType $type): void
+    {
+        static::$types[$name] = $type;
+    }
+
     protected static function create(string $name): NullableType
     {
         return match ($name) {

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mrap\GraphCool\Tests\Types;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Mrap\GraphCool\Tests\TestCase;
+use Mrap\GraphCool\Types\Type;
+
+class TypeTest extends TestCase
+{
+    public function testRegisterMakesCustomTypeResolvableByGet(): void
+    {
+        $custom = new ObjectType([
+            'name' => '_RegisterTestType',
+            'fields' => [
+                'ok' => GraphQLType::boolean(),
+            ],
+        ]);
+
+        Type::register('_RegisterTestType', $custom);
+
+        // get() must return the exact same instance (singleton) the schema needs.
+        self::assertSame($custom, Type::get('_RegisterTestType'));
+    }
+}


### PR DESCRIPTION
## What

Add `Type::register(string $name, NullableType $type): void` — seeds graphcool's type cache so app code can expose a bespoke (non-model) object/scalar type to the schema type loader.

## Why

graphcool no longer exposes the old `TypeLoader::register` hook. `Type::get()` only resolves built-in and model-derived names (via `createDynamic` → `model()`), so a custom result type defined by a consuming service fails schema validation/introspection with `Unknown entity: <name>`.

Surfaced while upgrading the `file` service (graphql-php 15): its `_FileStatistics` query-result object type had no way to register, breaking `__schema` introspection.

## Change

- `Type::register()` assigns into the existing `static $types` cache; `Type::get()` then returns that exact instance (satisfies graphql-php's type-singleton check).
- Test: `TypeTest::testRegisterMakesCustomTypeResolvableByGet`.

## Verification

Full suite green (443 tests, only the pre-existing `ClassFinderTest` env artifact). Verified end-to-end: the `file` service's full GraphQL introspection succeeds with `_FileStatistics` resolving as an OBJECT type under graphql-php 15.33.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)