### PR TITLE
fix: preserve node entity type so a model field named `model` cannot shadow it

### DIFF
--- a/src/DataSource/Mysql/MysqlDataProvider.php
+++ b/src/DataSource/Mysql/MysqlDataProvider.php
@@ -754,7 +754,11 @@ class MysqlDataProvider implements DataProvider
 
     protected function retrieveFiles(stdClass $data): stdClass
     {
-        $model = model($data->model);
+        // Use the preserved entity type: a model may define a field named `model`
+        // (e.g. the file service's File model), which would otherwise shadow the
+        // node's type on $data->model and break resolution.
+        $type = $data->{MysqlNodeReader::ENTITY_TYPE_KEY} ?? $data->model;
+        $model = model($type);
         foreach (get_object_vars($model) as $key => $item) {
             if (
                 !$item instanceof Field
@@ -766,7 +770,7 @@ class MysqlDataProvider implements DataProvider
             //can't use closure here, because there are subfields - graphql-php only allows closures at leaf-nodes
             //$value = $data->$key;
             //$data->$key = function() use($name, $id, $key, $value) {File::retrieve($name, $id, $key, $value);};
-            $data->$key = File::retrieve($data->model, $data->id, $key, $data->$key);
+            $data->$key = File::retrieve($type, $data->id, $key, $data->$key);
         }
         return $data;
     }

--- a/src/DataSource/Mysql/MysqlNodeReader.php
+++ b/src/DataSource/Mysql/MysqlNodeReader.php
@@ -14,6 +14,9 @@ use function Mrap\GraphCool\model;
 
 class MysqlNodeReader
 {
+    // Reserved key holding a node's true entity type (the `node.model` column),
+    // preserved so a model field literally named `model` cannot shadow it.
+    public const ENTITY_TYPE_KEY = '__graphcool_entity_type';
 
     /** @var string[] */
     protected array $nodeIds = [];
@@ -34,6 +37,9 @@ class MysqlNodeReader
         }
         $nodes = [];
         foreach ($this->fetchNodes($tenantId, $ids, $resultType) as $id => $node) {
+            // Preserve the true entity type before node properties (which may include
+            // a field literally named `model`) overwrite $node->model below.
+            $node->{self::ENTITY_TYPE_KEY} = $node->model;
             $nodes[$id] = Mysql::edgeReader()->injectEdgeClosures($node);
         }
         if (count($nodes) === 0) {

--- a/tests/DataSource/Mysql/MysqlNodeReaderTest.php
+++ b/tests/DataSource/Mysql/MysqlNodeReaderTest.php
@@ -43,6 +43,17 @@ class MysqlNodeReaderTest extends TestCase
         self::assertEquals('Huber', $result->last_name);
     }
 
+    public function testLoadPreservesTrueEntityType(): void
+    {
+        $this->mockLoad();
+        $reader = new MysqlNodeReader();
+        $result = $reader->load('hc123', 'asdf123123');
+
+        // The node's true entity type must survive under a reserved key so a model
+        // field literally named `model` cannot shadow it (file service File model).
+        self::assertSame('DummyModel', $result->{MysqlNodeReader::ENTITY_TYPE_KEY});
+    }
+
     protected function mockLoad(): void
     {
         require_once($this->dataPath().'/app/Models/DummyModel.php');


### PR DESCRIPTION
## Problem

A model may legitimately define a field named **`model`** — notably the file microservice's `File` model, whose `model` field stores the *owning* entity name (e.g. `"NoteAttachment"`, `"Customer"`). graphcool also stores a node's own entity type in the `node.model` column.

On load, `MysqlNodeReader` applies node properties onto the node object, so the `model` **field** value overwrites `$node->model` (the entity **type**). `MysqlDataProvider::retrieveFiles()` then calls `model($data->model)` with the foreign value → **`Unknown entity: NoteAttachment`**, breaking every file read/upload for such models.

This regressed from 0.17.x, where `retrieveFiles(string $name, …)` received the entity type explicitly; the refactor to derive it from `$data->model` introduced the shadowing.

## Fix

- `MysqlNodeReader`: preserve the true entity type (the `node.model` column) under a reserved key (`ENTITY_TYPE_KEY`) **before** node properties are applied.
- `MysqlDataProvider::retrieveFiles()`: resolve the model + `File::retrieve()` via that preserved type, falling back to `$data->model`.

No extra queries. The reserved key is internal (not a declared field, so it never surfaces in GraphQL output).

## Verification

- New regression test `MysqlNodeReaderTest::testLoadPreservesTrueEntityType`.
- Full suite green: **444 tests** (only the pre-existing `ClassFinderTest` container-path env failure remains).
- **End-to-end:** ran the file service in Docker (graphql-php 15.33.1, PHP 8.3) and drove `createFile(model:"NoteAttachment", …)`. Before: `Unknown entity: NoteAttachment`. After: `{id, filesize, file{url}}` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)